### PR TITLE
Fix `cargo contract build` command

### DIFF
--- a/drink-cli/src/executor.rs
+++ b/drink-cli/src/executor.rs
@@ -63,6 +63,7 @@ fn build_contract(app_state: &mut AppState) {
     if output.status.success() {
         app_state.print("Contract built successfully");
     } else {
+        // I always hit this error even if I install cargo-contract with `cargo +nightly install cargo-contract`
         let stderr = String::from_utf8_lossy(&output.stderr);
         app_state.print_error(&format!(
             "Error executing 'cargo contract' command:\n{stderr}"

--- a/drink-cli/src/executor.rs
+++ b/drink-cli/src/executor.rs
@@ -53,7 +53,7 @@ pub fn execute(app_state: &mut AppState) -> Result<()> {
 }
 
 fn build_contract(app_state: &mut AppState) {
-    let output = Command::new("cargo-contract")
+    let output = Command::new("cargo")
         .arg("contract")
         .arg("build")
         .arg("--release")
@@ -63,7 +63,6 @@ fn build_contract(app_state: &mut AppState) {
     if output.status.success() {
         app_state.print("Contract built successfully");
     } else {
-        // I always hit this error even if I install cargo-contract with `cargo +nightly install cargo-contract`
         let stderr = String::from_utf8_lossy(&output.stderr);
         app_state.print_error(&format!(
             "Error executing 'cargo contract' command:\n{stderr}"


### PR DESCRIPTION
I couldn't make the `build` command work. I even installed `cargo-contract` with `cargo +nightly install cargo-contract`.

![image](https://github.com/Cardinal-Cryptography/drink/assets/2915325/15a5c191-fcf8-446d-9dd6-f05545beb286)

To solve this error, I just had to change the command slightly. Please confirm whether this is the correct fix.
