### PR TITLE
Display the error we get from calling a contract's method

### DIFF
--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -96,9 +96,15 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
     };
 
     let account_id = contract.address.clone();
-    let Ok(data) = contract.transcode.encode(&message, args) else {
-        app_state.print_error("Failed to encode call data");
-        return;
+    let data = match contract.transcode.encode(&message, args)  {
+        Ok(data) => data,
+        Err(error_msg) => {
+            app_state.print_error(&format!(
+                "Failed to encode call data. Error:\n    {}",
+                error_msg,
+            ));
+            return;
+        },
     };
 
     let result = app_state.sandbox.call_contract(account_id, data);

--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -99,7 +99,7 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
     };
 
     let account_id = contract.address.clone();
-    let data = match contract.transcode.encode(&message, args)  {
+    let data = match contract.transcode.encode(&message, args) {
         Ok(data) => data,
         Err(error_msg) => {
             app_state.print_error(&format!(
@@ -107,7 +107,7 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
                 error_msg,
             ));
             return;
-        },
+        }
     };
 
     let result = app_state.sandbox.call_contract(

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -65,7 +65,10 @@ impl Session {
     }
 
     pub fn with_transcoder(self, transcoder: ContractMessageTranscoder) -> Self {
-        Self { transcoder, ..self }
+        Self {
+            transcoder: Some(transcoder),
+            ..self
+        }
     }
 
     pub fn deploy(

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Cardinal-Cryptography/drink"
 version = "0.1.0"
 
 [dependencies]
-ink = { version = "4.2.0", default-features = false, features = ["ink-debug"] }
+ink = { version = "=4.2.1", default-features = false, features = ["ink-debug"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Cardinal-Cryptography/drink"
 version = "0.1.0"
 
 [dependencies]
-ink = { version = "4.2.0", default-features = false, features = ["ink-debug"] }
+ink = { version = "=4.2.1", default-features = false, features = ["ink-debug"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
In the simplest possible way, this just prints to the console the error we get when calling a contract's method.

Also, it introduces the `=4.2.1` fixed version for the example contracts' `ink` dependences, because "Fool me once [...]" ;)