### PR TITLE
Use `Session` in CLI

### DIFF
--- a/drink-cli/src/app_state/contracts.rs
+++ b/drink-cli/src/app_state/contracts.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, rc::Rc};
 
 use contract_transcode::ContractMessageTranscoder;
 use sp_core::crypto::AccountId32;
@@ -10,7 +10,7 @@ pub struct Contract {
     pub name: String,
     pub address: AccountId32,
     pub base_path: PathBuf,
-    pub transcode: ContractMessageTranscoder,
+    pub transcoder: Rc<ContractMessageTranscoder>,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]

--- a/drink-cli/src/app_state/mod.rs
+++ b/drink-cli/src/app_state/mod.rs
@@ -1,7 +1,7 @@
 use std::{env, path::PathBuf};
 
 pub use contracts::{Contract, ContractIndex, ContractRegistry};
-use drink::{Sandbox, Weight, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT};
+use drink::{session::Session, Weight, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT};
 use sp_core::crypto::AccountId32;
 pub use user_input::UserInput;
 
@@ -9,6 +9,7 @@ use crate::app_state::output::Output;
 
 mod contracts;
 mod output;
+pub mod print;
 mod user_input;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -59,7 +60,7 @@ impl Default for UiState {
 }
 
 pub struct AppState {
-    pub sandbox: Sandbox,
+    pub session: Session,
     pub chain_info: ChainInfo,
     pub ui_state: UiState,
     pub contracts: ContractRegistry,
@@ -68,7 +69,7 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            sandbox: Sandbox::new().expect("Failed to create sandbox"),
+            session: Session::new(None).expect("Failed to create drinking session"),
             chain_info: Default::default(),
             ui_state: Default::default(),
             contracts: Default::default(),

--- a/drink-cli/src/app_state/print.rs
+++ b/drink-cli/src/app_state/print.rs
@@ -38,19 +38,6 @@ impl AppState {
         );
     }
 
-    pub fn print_contract_action<R>(&mut self, result: &ContractResult<R, u128>) {
-        let mut output = format!(
-            "Gas consumed: {:?}\nGas required: {:?}\nDebug buffer:\n",
-            result.gas_consumed, result.gas_required
-        );
-
-        for line in &decode_debug_buffer(&result.debug_message) {
-            output.push_str(&format!("  {line}\n"));
-        }
-
-        self.print(&output)
-    }
-
     fn print_sequence<'a, I: Iterator<Item = &'a str>>(&mut self, seq: I, style: Style) {
         for line in seq {
             self.ui_state
@@ -58,4 +45,17 @@ impl AppState {
                 .push(Span::styled(line.to_string(), style).into());
         }
     }
+}
+
+pub fn format_contract_action<R>(result: &ContractResult<R, u128>) -> String {
+    let mut output = format!(
+        "Gas consumed: {:?}\nGas required: {:?}\nDebug buffer:\n",
+        result.gas_consumed, result.gas_required
+    );
+
+    for line in &decode_debug_buffer(&result.debug_message) {
+        output.push_str(&format!("  {line}\n"));
+    }
+
+    output
 }

--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -84,7 +84,10 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
         .set_transcoder(Some(contract.transcoder.clone()));
 
     let address = contract.address.clone();
-    match app_state.session.call(Some(address), &message, &args) {
+    match app_state
+        .session
+        .call_with_address(address, &message, &args)
+    {
         Ok(result) => app_state.print(&format!("Result: {:?}", result)),
         Err(err) => app_state.print_error(&format!("Failed to call contract\n{err}")),
     };

--- a/drink-cli/src/executor/mod.rs
+++ b/drink-cli/src/executor/mod.rs
@@ -67,7 +67,7 @@ pub fn execute(app_state: &mut AppState) -> Result<()> {
 
 fn build_blocks(app_state: &mut AppState, count: u64) {
     for _ in 0..count {
-        app_state.sandbox.build_block();
+        app_state.session.chain_api().build_block();
     }
 
     app_state.chain_info.block_height += count;
@@ -76,6 +76,9 @@ fn build_blocks(app_state: &mut AppState, count: u64) {
 }
 
 fn add_tokens(app_state: &mut AppState, recipient: AccountId32, value: u128) {
-    app_state.sandbox.add_tokens(recipient.clone(), value);
+    app_state
+        .session
+        .chain_api()
+        .add_tokens(recipient.clone(), value);
     app_state.print(&format!("{value} tokens added to {recipient}",));
 }

--- a/drink-cli/src/ui/mod.rs
+++ b/drink-cli/src/ui/mod.rs
@@ -4,7 +4,6 @@ mod footer;
 mod help;
 mod layout;
 mod output;
-mod print;
 mod user_input;
 
 use std::{io, io::Stdout};

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -4,7 +4,9 @@ use frame_support::{dispatch::DispatchError, sp_runtime::AccountId32, weights::W
 use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult};
 use thiserror::Error;
 
-use crate::{contract_api::ContractApi, Sandbox, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT};
+use crate::{
+    chain_api::ChainApi, contract_api::ContractApi, Sandbox, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT,
+};
 
 #[derive(Error, Debug)]
 pub enum SessionError {
@@ -60,23 +62,54 @@ impl Session {
         Self { actor, ..self }
     }
 
+    pub fn set_actor(&mut self, actor: AccountId32) {
+        self.actor = actor;
+    }
+
     pub fn with_gas_limit(self, gas_limit: Weight) -> Self {
         Self { gas_limit, ..self }
     }
 
-    pub fn with_transcoder(self, transcoder: ContractMessageTranscoder) -> Self {
-        Self { transcoder, ..self }
+    pub fn set_gas_limit(&mut self, gas_limit: Weight) {
+        self.gas_limit = gas_limit;
     }
 
-    pub fn deploy(
+    pub fn with_transcoder(self, transcoder: ContractMessageTranscoder) -> Self {
+        Self {
+            transcoder: Some(transcoder),
+            ..self
+        }
+    }
+
+    pub fn set_transcoder(&mut self, transcoder: ContractMessageTranscoder) {
+        self.transcoder = Some(transcoder);
+    }
+
+    pub fn chain_api(&mut self) -> &mut impl ChainApi {
+        &mut self.sandbox
+    }
+
+    pub fn deploy_and(
         mut self,
         contract_bytes: Vec<u8>,
         constructor: &str,
         args: &[&str],
         salt: Vec<u8>,
     ) -> Result<Self, SessionError> {
+        self.deploy(contract_bytes, constructor, args, salt)
+            .map(|_| self)
+    }
+
+    pub fn deploy(
+        &mut self,
+        contract_bytes: Vec<u8>,
+        constructor: &str,
+        args: &[&str],
+        salt: Vec<u8>,
+    ) -> Result<AccountId32, SessionError> {
         let data = self
             .transcoder
+            .as_ref()
             .ok_or(SessionError::NoTranscoder)?
             .encode(constructor, args)
             .map_err(|err| SessionError::Encoding(err.to_string()))?;
@@ -89,22 +122,30 @@ impl Session {
             self.gas_limit,
         );
 
-        match &result.result {
+        let ret = match &result.result {
             Ok(exec_result) if exec_result.result.did_revert() => {
                 Err(SessionError::DeploymentReverted)
             }
             Ok(exec_result) => {
-                self.deploy_returns.push(exec_result.account_id.clone());
-                self.deploy_results.push(result);
-                Ok(self)
+                let address = exec_result.account_id.clone();
+                self.deploy_returns.push(address.clone());
+                Ok(address)
             }
             Err(err) => Err(SessionError::DeploymentFailed(*err)),
-        }
+        };
+
+        self.deploy_results.push(result);
+        ret
     }
 
-    pub fn call(mut self, message: &str, args: &[&str]) -> Result<Self, SessionError> {
+    pub fn call_and(mut self, message: &str, args: &[&str]) -> Result<Self, SessionError> {
+        self.call(message, args).map(|_| self)
+    }
+
+    pub fn call(&mut self, message: &str, args: &[&str]) -> Result<Value, SessionError> {
         let data = self
             .transcoder
+            .as_ref()
             .ok_or(SessionError::NoTranscoder)?
             .encode(message, args)
             .map_err(|err| SessionError::Encoding(err.to_string()))?;
@@ -114,21 +155,24 @@ impl Session {
             .sandbox
             .call_contract(address, data, self.actor.clone(), self.gas_limit);
 
-        match &result.result {
+        let ret = match &result.result {
             Ok(exec_result) if exec_result.did_revert() => Err(SessionError::CallReverted),
             Ok(exec_result) => {
                 let decoded = self
                     .transcoder
+                    .as_ref()
                     .ok_or(SessionError::NoTranscoder)?
                     .decode_return(message, &mut exec_result.data.as_slice())
                     .map_err(|err| SessionError::Decoding(err.to_string()))?;
 
-                self.call_returns.push(decoded);
-                self.call_results.push(result);
-                Ok(self)
+                self.call_returns.push(decoded.clone());
+                Ok(decoded)
             }
             Err(err) => Err(SessionError::CallFailed(*err)),
-        }
+        };
+
+        self.call_results.push(result);
+        ret
     }
 
     pub fn last_deploy_result(&self) -> Option<&ContractInstantiateResult<AccountId32, u128>> {

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -1,3 +1,5 @@
+use std::{mem, rc::Rc};
+
 pub use contract_transcode;
 use contract_transcode::{ContractMessageTranscoder, Value};
 use frame_support::{dispatch::DispatchError, sp_runtime::AccountId32, weights::Weight};
@@ -36,7 +38,7 @@ pub struct Session {
     actor: AccountId32,
     gas_limit: Weight,
 
-    transcoder: Option<ContractMessageTranscoder>,
+    transcoder: Option<Rc<ContractMessageTranscoder>>,
 
     deploy_results: Vec<ContractInstantiateResult<AccountId32, u128>>,
     deploy_returns: Vec<AccountId32>,
@@ -45,7 +47,7 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn new(transcoder: Option<ContractMessageTranscoder>) -> Result<Self, SessionError> {
+    pub fn new(transcoder: Option<Rc<ContractMessageTranscoder>>) -> Result<Self, SessionError> {
         Ok(Self {
             sandbox: Sandbox::new().map_err(SessionError::Drink)?,
             actor: DEFAULT_ACTOR,
@@ -62,27 +64,27 @@ impl Session {
         Self { actor, ..self }
     }
 
-    pub fn set_actor(&mut self, actor: AccountId32) {
-        self.actor = actor;
+    pub fn set_actor(&mut self, actor: AccountId32) -> AccountId32 {
+        mem::replace(&mut self.actor, actor)
     }
 
     pub fn with_gas_limit(self, gas_limit: Weight) -> Self {
         Self { gas_limit, ..self }
     }
 
-    pub fn set_gas_limit(&mut self, gas_limit: Weight) {
-        self.gas_limit = gas_limit;
+    pub fn set_gas_limit(&mut self, gas_limit: Weight) -> Weight {
+        mem::replace(&mut self.gas_limit, gas_limit)
     }
 
-    pub fn with_transcoder(self, transcoder: ContractMessageTranscoder) -> Self {
-        Self {
-            transcoder: Some(transcoder),
-            ..self
-        }
+    pub fn with_transcoder(self, transcoder: Option<Rc<ContractMessageTranscoder>>) -> Self {
+        Self { transcoder, ..self }
     }
 
-    pub fn set_transcoder(&mut self, transcoder: ContractMessageTranscoder) {
-        self.transcoder = Some(transcoder);
+    pub fn set_transcoder(
+        &mut self,
+        transcoder: Option<Rc<ContractMessageTranscoder>>,
+    ) -> Option<Rc<ContractMessageTranscoder>> {
+        mem::replace(&mut self.transcoder, transcoder)
     }
 
     pub fn chain_api(&mut self) -> &mut impl ChainApi {
@@ -93,7 +95,7 @@ impl Session {
         mut self,
         contract_bytes: Vec<u8>,
         constructor: &str,
-        args: &[&str],
+        args: &[String],
         salt: Vec<u8>,
     ) -> Result<Self, SessionError> {
         self.deploy(contract_bytes, constructor, args, salt)
@@ -104,7 +106,7 @@ impl Session {
         &mut self,
         contract_bytes: Vec<u8>,
         constructor: &str,
-        args: &[&str],
+        args: &[String],
         salt: Vec<u8>,
     ) -> Result<AccountId32, SessionError> {
         let data = self
@@ -138,11 +140,21 @@ impl Session {
         ret
     }
 
-    pub fn call_and(mut self, message: &str, args: &[&str]) -> Result<Self, SessionError> {
-        self.call(message, args).map(|_| self)
+    pub fn call_and(
+        mut self,
+        address: Option<AccountId32>,
+        message: &str,
+        args: &[String],
+    ) -> Result<Self, SessionError> {
+        self.call(address, message, args).map(|_| self)
     }
 
-    pub fn call(&mut self, message: &str, args: &[&str]) -> Result<Value, SessionError> {
+    pub fn call(
+        &mut self,
+        address: Option<AccountId32>,
+        message: &str,
+        args: &[String],
+    ) -> Result<Value, SessionError> {
         let data = self
             .transcoder
             .as_ref()
@@ -150,7 +162,15 @@ impl Session {
             .encode(message, args)
             .map_err(|err| SessionError::Encoding(err.to_string()))?;
 
-        let address = self.last_deploy_return().ok_or(SessionError::NoContract)?;
+        let address = match address {
+            Some(address) => address,
+            None => self
+                .deploy_returns
+                .last()
+                .ok_or(SessionError::NoContract)?
+                .clone(),
+        };
+
         let result = self
             .sandbox
             .call_contract(address, data, self.actor.clone(), self.gas_limit);

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -140,16 +140,34 @@ impl Session {
         ret
     }
 
-    pub fn call_and(
+    pub fn call_and(mut self, message: &str, args: &[String]) -> Result<Self, SessionError> {
+        self.call_internal(None, message, args).map(|_| self)
+    }
+
+    pub fn call_with_address_and(
         mut self,
-        address: Option<AccountId32>,
+        address: AccountId32,
         message: &str,
         args: &[String],
     ) -> Result<Self, SessionError> {
-        self.call(address, message, args).map(|_| self)
+        self.call_internal(Some(address), message, args)
+            .map(|_| self)
     }
 
-    pub fn call(
+    pub fn call(&mut self, message: &str, args: &[String]) -> Result<Value, SessionError> {
+        self.call_internal(None, message, args)
+    }
+
+    pub fn call_with_address(
+        &mut self,
+        address: AccountId32,
+        message: &str,
+        args: &[String],
+    ) -> Result<Value, SessionError> {
+        self.call_internal(Some(address), message, args)
+    }
+
+    fn call_internal(
         &mut self,
         address: Option<AccountId32>,
         message: &str,

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -56,7 +56,7 @@ mod tests {
     fn initialization() -> Result<(), Box<dyn Error>> {
         let init_value = Session::new(Some(Rc::new(transcoder())))?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
-            .call_and(None, "get", &[])?
+            .call_and("get", &[])?
             .last_call_return()
             .expect("Call was successful");
 
@@ -69,10 +69,10 @@ mod tests {
     fn flipping() -> Result<(), Box<dyn Error>> {
         let init_value = Session::new(Some(Rc::new(transcoder())))?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
-            .call_and(None, "flip", &[])?
-            .call_and(None, "flip", &[])?
-            .call_and(None, "flip", &[])?
-            .call_and(None, "get", &[])?
+            .call_and("flip", &[])?
+            .call_and("flip", &[])?
+            .call_and("flip", &[])?
+            .call_and("get", &[])?
             .last_call_return()
             .expect("Call was successful");
 

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -39,9 +39,11 @@ mod tests {
         Session,
     };
 
-    fn transcoder() -> ContractMessageTranscoder {
-        ContractMessageTranscoder::load(PathBuf::from("./target/ink/flipper.json"))
-            .expect("Failed to create transcoder")
+    fn transcoder() -> Option<Rc<ContractMessageTranscoder>> {
+        Some(Rc::new(
+            ContractMessageTranscoder::load(PathBuf::from("./target/ink/flipper.json"))
+                .expect("Failed to create transcoder"),
+        ))
     }
 
     fn bytes() -> Vec<u8> {
@@ -54,7 +56,7 @@ mod tests {
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::new(Some(Rc::new(transcoder())))?
+        let init_value = Session::new(transcoder())?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
             .call_and("get", &[])?
             .last_call_return()
@@ -67,7 +69,7 @@ mod tests {
 
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::new(Some(Rc::new(transcoder())))?
+        let init_value = Session::new(transcoder())?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
             .call_and("flip", &[])?
             .call_and("flip", &[])?

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -32,7 +32,7 @@ mod flipper {
 
 #[cfg(test)]
 mod tests {
-    use std::{error::Error, fs, path::PathBuf};
+    use std::{error::Error, fs, path::PathBuf, rc::Rc};
 
     use drink::session::{
         contract_transcode::{ContractMessageTranscoder, Tuple, Value},
@@ -54,9 +54,9 @@ mod tests {
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::new(Some(transcoder()))?
-            .deploy_and(bytes(), "new", &["true"], vec![])?
-            .call_and("get", &[])?
+        let init_value = Session::new(Some(Rc::new(transcoder())))?
+            .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
+            .call_and(None, "get", &[])?
             .last_call_return()
             .expect("Call was successful");
 
@@ -67,12 +67,12 @@ mod tests {
 
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::new(Some(transcoder()))?
-            .deploy_and(bytes(), "new", &["true"], vec![])?
-            .call_and("flip", &[])?
-            .call_and("flip", &[])?
-            .call_and("flip", &[])?
-            .call_and("get", &[])?
+        let init_value = Session::new(Some(Rc::new(transcoder())))?
+            .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
+            .call_and(None, "flip", &[])?
+            .call_and(None, "flip", &[])?
+            .call_and(None, "flip", &[])?
+            .call_and(None, "get", &[])?
             .last_call_return()
             .expect("Call was successful");
 

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -55,8 +55,8 @@ mod tests {
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
         let init_value = Session::new(Some(transcoder()))?
-            .deploy(bytes(), "new", &["true"], vec![])?
-            .call("get", &[])?
+            .deploy_and(bytes(), "new", &["true"], vec![])?
+            .call_and("get", &[])?
             .last_call_return()
             .expect("Call was successful");
 
@@ -68,11 +68,11 @@ mod tests {
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
         let init_value = Session::new(Some(transcoder()))?
-            .deploy(bytes(), "new", &["true"], vec![])?
-            .call("flip", &[])?
-            .call("flip", &[])?
-            .call("flip", &[])?
-            .call("get", &[])?
+            .deploy_and(bytes(), "new", &["true"], vec![])?
+            .call_and("flip", &[])?
+            .call_and("flip", &[])?
+            .call_and("flip", &[])?
+            .call_and("get", &[])?
             .last_call_return()
             .expect("Call was successful");
 


### PR DESCRIPTION
1. `Session` has now two APIs: for chaining (`with_*` and `*_and`) and singular actions
2. removed duplicated code from `drink-cli/executor` (core code was duplicating `Session`)
3. some mambo-jumbo for sharing `ContractMessageTranscoder` (it is not `Clone` nor `Copy`...)