### PR TITLE
Allow starting the CLI with an initial pwd set

### DIFF
--- a/drink-cli/src/app_state/mod.rs
+++ b/drink-cli/src/app_state/mod.rs
@@ -47,6 +47,17 @@ pub struct UiState {
     pub show_help: bool,
 }
 
+impl UiState {
+    pub fn new(pwd_override: Option<PathBuf>) -> Self {
+        let pwd = pwd_override.unwrap_or(
+            env::current_dir().expect("Failed to get current directory"));
+        UiState {
+            pwd,
+            ..Default::default()
+        }
+    }
+}
+
 impl Default for UiState {
     fn default() -> Self {
         UiState {
@@ -64,6 +75,15 @@ pub struct AppState {
     pub chain_info: ChainInfo,
     pub ui_state: UiState,
     pub contracts: ContractRegistry,
+}
+
+impl AppState {
+    pub fn new(pwd_override: Option<PathBuf>) -> Self {
+        AppState {
+            ui_state: UiState::new(pwd_override),
+            ..Default::default()
+        }
+    }
 }
 
 impl Default for AppState {

--- a/drink-cli/src/app_state/mod.rs
+++ b/drink-cli/src/app_state/mod.rs
@@ -49,24 +49,22 @@ pub struct UiState {
 
 impl UiState {
     pub fn new(pwd_override: Option<PathBuf>) -> Self {
-        let pwd = pwd_override.unwrap_or(
-            env::current_dir().expect("Failed to get current directory"));
+        let pwd = pwd_override.unwrap_or_else(
+            || env::current_dir().expect("Failed to get current directory"));
+
         UiState {
             pwd,
-            ..Default::default()
+            mode: Default::default(),
+            user_input: Default::default(),
+            output: Default::default(),
+            show_help: false,
         }
     }
 }
 
 impl Default for UiState {
     fn default() -> Self {
-        UiState {
-            pwd: env::current_dir().expect("Failed to get current directory"),
-            mode: Default::default(),
-            user_input: Default::default(),
-            output: Default::default(),
-            show_help: false,
-        }
+        UiState::new(None)
     }
 }
 
@@ -80,19 +78,16 @@ pub struct AppState {
 impl AppState {
     pub fn new(pwd_override: Option<PathBuf>) -> Self {
         AppState {
+            session: Session::new(None).expect("Failed to create drinking session"),
+            chain_info: Default::default(),
             ui_state: UiState::new(pwd_override),
-            ..Default::default()
+            contracts: Default::default(),
         }
     }
 }
 
 impl Default for AppState {
     fn default() -> Self {
-        Self {
-            session: Session::new(None).expect("Failed to create drinking session"),
-            chain_info: Default::default(),
-            ui_state: Default::default(),
-            contracts: Default::default(),
-        }
+        Self::new(None)
     }
 }

--- a/drink-cli/src/main.rs
+++ b/drink-cli/src/main.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
 
 use crate::ui::run_ui;
 
@@ -7,6 +9,15 @@ mod cli;
 mod executor;
 mod ui;
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Starts the CLI in the provided directory
+    #[arg(short, long, value_name = "DIRECTORY", )]
+    path: Option<PathBuf>,
+}
+
 fn main() -> Result<()> {
-    run_ui()
+    let args = Args::parse();
+    run_ui(args.path)
 }

--- a/drink-cli/src/ui/mod.rs
+++ b/drink-cli/src/ui/mod.rs
@@ -7,6 +7,7 @@ mod output;
 mod user_input;
 
 use std::{io, io::Stdout};
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use crossterm::{
@@ -28,9 +29,9 @@ use crate::{
 
 type Terminal = ratatui::Terminal<CrosstermBackend<Stdout>>;
 
-pub fn run_ui() -> Result<()> {
+pub fn run_ui(pwd: Option<PathBuf>) -> Result<()> {
     let mut terminal = setup_dedicated_terminal()?;
-    let app_result = run_ui_app(&mut terminal);
+    let app_result = run_ui_app(&mut terminal, pwd);
     restore_original_terminal(terminal)?;
     app_result
 }
@@ -53,8 +54,8 @@ fn restore_original_terminal(mut terminal: Terminal) -> Result<()> {
     terminal.show_cursor().map_err(|e| anyhow!(e))
 }
 
-fn run_ui_app(terminal: &mut Terminal) -> Result<()> {
-    let mut app_state = AppState::default();
+fn run_ui_app(terminal: &mut Terminal, pwd_override: Option<PathBuf>) -> Result<()> {
+    let mut app_state = AppState::new(pwd_override);
 
     loop {
         terminal.draw(|f| layout(f, &mut app_state))?;


### PR DESCRIPTION
This was mentioned as a half-measure for #8 and it seems to cover a lot of the use cases (assuming users start `drink-cli` to mostly work on one contract.

Usage:
```
$ drink-cli --help
Usage: drink-cli [OPTIONS]

Options:
  -p, --path <DIRECTORY>  Starts the CLI in the provided directory
  -h, --help              Print help
  -V, --version           Print version
```

So you're able to start it like:
```
$ drink-cli examples/flipper
```
And immediately call `build`.