### PR TITLE
Make `drink` generic over runtime

### DIFF
--- a/drink-cli/src/app_state/mod.rs
+++ b/drink-cli/src/app_state/mod.rs
@@ -1,7 +1,7 @@
 use std::{env, path::PathBuf};
 
 pub use contracts::{Contract, ContractIndex, ContractRegistry};
-use drink::{session::Session, Weight, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT};
+use drink::{runtime::MinimalRuntime, session::Session, Weight, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT};
 use sp_core::crypto::AccountId32;
 pub use user_input::UserInput;
 
@@ -60,7 +60,7 @@ impl Default for UiState {
 }
 
 pub struct AppState {
-    pub session: Session,
+    pub session: Session<MinimalRuntime>,
     pub chain_info: ChainInfo,
     pub ui_state: UiState,
     pub contracts: ContractRegistry,

--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -1,16 +1,24 @@
-use std::{env, fs, path::PathBuf, rc::Rc};
-use std::path::Path;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
-use contract_transcode::ContractMessageTranscoder;
 use contract_build::{BuildMode, ExecuteArgs, ManifestPath, OptimizationPasses, Verbosity};
+use contract_transcode::ContractMessageTranscoder;
 
-use crate::app_state::{print::format_contract_action, AppState, Contract};
-use crate::executor::error::BuildError;
+use crate::{
+    app_state::{print::format_contract_action, AppState, Contract},
+    executor::error::BuildError,
+};
 
 fn build_result(app_state: &mut AppState) -> Result<String, BuildError> {
     let path_to_cargo_toml = app_state.ui_state.pwd.join(Path::new("Cargo.toml"));
     let manifest_path = ManifestPath::new(path_to_cargo_toml.clone()).map_err(|err| {
-        BuildError::InvalidManifest { manifest_path: path_to_cargo_toml, err }
+        BuildError::InvalidManifest {
+            manifest_path: path_to_cargo_toml,
+            err,
+        }
     })?;
 
     let args = ExecuteArgs {
@@ -23,10 +31,11 @@ fn build_result(app_state: &mut AppState) -> Result<String, BuildError> {
 
     contract_build::execute(args)
         .map_err(|err| BuildError::BuildFailed { err })?
-        .dest_wasm.ok_or(BuildError::WasmNotGenerated)?
+        .dest_wasm
+        .ok_or(BuildError::WasmNotGenerated)?
         .canonicalize()
         .map_err(|err| BuildError::InvalidDestPath { err })
-        .map(|pb| { pb.to_string_lossy().to_string() })
+        .map(|pb| pb.to_string_lossy().to_string())
 }
 
 /// Build the contract in the current directory.
@@ -39,7 +48,7 @@ pub fn build(app_state: &mut AppState) {
 
 pub fn deploy(app_state: &mut AppState, constructor: String, args: Vec<String>, salt: Vec<u8>) {
     // Get raw contract bytes
-    let Some((contract_name, contract_file)) = find_wasm_blob() else {
+    let Some((contract_name, contract_file)) = find_wasm_blob(&app_state.ui_state.pwd) else {
         app_state.print_error("Failed to find contract file");
         return;
     };
@@ -110,8 +119,7 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
     }
 }
 
-fn find_wasm_blob() -> Option<(String, PathBuf)> {
-    let pwd = env::current_dir().expect("Failed to get current directory");
+fn find_wasm_blob(pwd: &Path) -> Option<(String, PathBuf)> {
     let Ok(entries) = fs::read_dir(pwd.join("target/ink")) else {
         return None;
     };

--- a/drink-cli/src/executor/mod.rs
+++ b/drink-cli/src/executor/mod.rs
@@ -68,10 +68,12 @@ pub fn execute(app_state: &mut AppState) -> Result<()> {
 
 fn build_blocks(app_state: &mut AppState, count: u64) {
     for _ in 0..count {
-        app_state.session.chain_api().build_block();
+        app_state.chain_info.block_height = app_state
+            .session
+            .chain_api()
+            .build_block()
+            .expect("Failed to build block - chain is broken");
     }
-
-    app_state.chain_info.block_height += count;
 
     app_state.print(&format!("{count} blocks built"));
 }
@@ -81,5 +83,5 @@ fn add_tokens(app_state: &mut AppState, recipient: AccountId32, value: u128) {
         .session
         .chain_api()
         .add_tokens(recipient.clone(), value);
-    app_state.print(&format!("{value} tokens added to {recipient}", ));
+    app_state.print(&format!("{value} tokens added to {recipient}",));
 }

--- a/drink-cli/src/executor/mod.rs
+++ b/drink-cli/src/executor/mod.rs
@@ -67,13 +67,11 @@ pub fn execute(app_state: &mut AppState) -> Result<()> {
 }
 
 fn build_blocks(app_state: &mut AppState, count: u64) {
-    for _ in 0..count {
-        app_state.chain_info.block_height = app_state
-            .session
-            .chain_api()
-            .build_block()
-            .expect("Failed to build block - chain is broken");
-    }
+    app_state.chain_info.block_height = app_state
+        .session
+        .chain_api()
+        .build_blocks(count)
+        .expect("Failed to build block - chain is broken");
 
     app_state.print(&format!("{count} blocks built"));
 }

--- a/drink/src/chain_api.rs
+++ b/drink/src/chain_api.rs
@@ -2,18 +2,23 @@
 
 use frame_support::{sp_runtime::AccountId32, traits::tokens::currency::Currency};
 
-use crate::{Runtime, Sandbox};
+use crate::{DrinkResult, Error, Runtime, Sandbox};
 
 /// Interface for basic chain operations.
 pub trait ChainApi {
-    /// Build a new empty block.
-    fn build_block(&mut self);
+    /// Return the current height of the chain.
+    fn current_height(&mut self) -> u64;
 
-    /// Build `n` empty blocks.
-    fn build_blocks(&mut self, n: u32) {
+    /// Build a new empty block and return the new height.
+    fn build_block(&mut self) -> DrinkResult<u64>;
+
+    /// Build `n` empty blocks and return the new height.
+    fn build_blocks(&mut self, n: u32) -> DrinkResult<u64> {
+        let mut last_block = None;
         for _ in 0..n {
-            self.build_block();
+            last_block = Some(self.build_block()?);
         }
+        Ok(last_block.unwrap_or_else(|| self.current_height()))
     }
 
     /// Add tokens to an account.
@@ -21,26 +26,18 @@ pub trait ChainApi {
 }
 
 impl<R: Runtime> ChainApi for Sandbox<R> {
-    fn build_block(&mut self) {
-        // let new_block = self.externalities.execute_with(|| {
-        //     let current_block = System::block_number();
-        //
-        //     Contracts::on_finalize(current_block);
-        //     Timestamp::on_finalize(current_block);
-        //     Balances::on_finalize(current_block);
-        //
-        //     let parent_hash = if current_block > 1 {
-        //         System::finalize().hash()
-        //     } else {
-        //         System::parent_hash()
-        //     };
-        //
-        //     System::initialize(&(current_block + 1), &parent_hash, &Default::default());
-        //
-        //     current_block + 1
-        // });
+    fn current_height(&mut self) -> u64 {
+        self.externalities
+            .execute_with(|| frame_system::Pallet::<R>::block_number())
+    }
 
-        // self.init_block(new_block);
+    fn build_block(&mut self) -> DrinkResult<u64> {
+        let current_block = self.current_height();
+        self.externalities.execute_with(|| {
+            let block_hash = R::finalize_block(current_block).map_err(Error::BlockFinalize)?;
+            R::initialize_block(current_block + 1, block_hash).map_err(Error::BlockInitialize)?;
+            Ok(current_block + 1)
+        })
     }
 
     fn add_tokens(&mut self, address: AccountId32, amount: u128) {

--- a/drink/src/chain_api.rs
+++ b/drink/src/chain_api.rs
@@ -1,14 +1,8 @@
 //! Basic chain API.
 
-use frame_support::{
-    sp_runtime::AccountId32,
-    traits::{Currency, Hooks},
-};
+use frame_support::{sp_runtime::AccountId32, traits::tokens::currency::Currency};
 
-use crate::{
-    runtime::{Balances, Contracts, Runtime, System, Timestamp},
-    Sandbox,
-};
+use crate::{Runtime, Sandbox};
 
 /// Interface for basic chain operations.
 pub trait ChainApi {
@@ -50,8 +44,8 @@ impl<R: Runtime> ChainApi for Sandbox<R> {
     }
 
     fn add_tokens(&mut self, address: AccountId32, amount: u128) {
-        // self.externalities.execute_with(|| {
-        //     let _ = Balances::deposit_creating(&address, amount);
-        // });
+        self.externalities.execute_with(|| {
+            let _ = pallet_balances::Pallet::<R>::deposit_creating(&address, amount);
+        });
     }
 }

--- a/drink/src/chain_api.rs
+++ b/drink/src/chain_api.rs
@@ -6,7 +6,7 @@ use frame_support::{
 };
 
 use crate::{
-    runtime::{Balances, Contracts, System, Timestamp},
+    runtime::{Balances, Contracts, Runtime, System, Timestamp},
     Sandbox,
 };
 
@@ -26,32 +26,32 @@ pub trait ChainApi {
     fn add_tokens(&mut self, address: AccountId32, amount: u128);
 }
 
-impl ChainApi for Sandbox {
+impl<R: Runtime> ChainApi for Sandbox<R> {
     fn build_block(&mut self) {
-        let new_block = self.externalities.execute_with(|| {
-            let current_block = System::block_number();
+        // let new_block = self.externalities.execute_with(|| {
+        //     let current_block = System::block_number();
+        //
+        //     Contracts::on_finalize(current_block);
+        //     Timestamp::on_finalize(current_block);
+        //     Balances::on_finalize(current_block);
+        //
+        //     let parent_hash = if current_block > 1 {
+        //         System::finalize().hash()
+        //     } else {
+        //         System::parent_hash()
+        //     };
+        //
+        //     System::initialize(&(current_block + 1), &parent_hash, &Default::default());
+        //
+        //     current_block + 1
+        // });
 
-            Contracts::on_finalize(current_block);
-            Timestamp::on_finalize(current_block);
-            Balances::on_finalize(current_block);
-
-            let parent_hash = if current_block > 1 {
-                System::finalize().hash()
-            } else {
-                System::parent_hash()
-            };
-
-            System::initialize(&(current_block + 1), &parent_hash, &Default::default());
-
-            current_block + 1
-        });
-
-        self.init_block(new_block);
+        // self.init_block(new_block);
     }
 
     fn add_tokens(&mut self, address: AccountId32, amount: u128) {
-        self.externalities.execute_with(|| {
-            let _ = Balances::deposit_creating(&address, amount);
-        });
+        // self.externalities.execute_with(|| {
+        //     let _ = Balances::deposit_creating(&address, amount);
+        // });
     }
 }

--- a/drink/src/chain_api.rs
+++ b/drink/src/chain_api.rs
@@ -13,7 +13,7 @@ pub trait ChainApi {
     fn build_block(&mut self) -> DrinkResult<u64>;
 
     /// Build `n` empty blocks and return the new height.
-    fn build_blocks(&mut self, n: u32) -> DrinkResult<u64> {
+    fn build_blocks(&mut self, n: u64) -> DrinkResult<u64> {
         let mut last_block = None;
         for _ in 0..n {
             last_block = Some(self.build_block()?);

--- a/drink/src/contract_api.rs
+++ b/drink/src/contract_api.rs
@@ -4,10 +4,7 @@ use frame_support::{sp_runtime::AccountId32, weights::Weight};
 use pallet_contracts::Determinism;
 use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult};
 
-use crate::{
-    runtime::{Contracts, Runtime},
-    Sandbox,
-};
+use crate::{runtime::Runtime, Sandbox};
 
 /// Interface for contract-related operations.
 pub trait ContractApi {
@@ -41,7 +38,7 @@ impl<R: Runtime> ContractApi for Sandbox<R> {
         gas_limit: Weight,
     ) -> ContractInstantiateResult<AccountId32, u128> {
         self.externalities.execute_with(|| {
-            Contracts::bare_instantiate(
+            pallet_contracts::Pallet::<R>::bare_instantiate(
                 origin,
                 0,
                 gas_limit,
@@ -62,7 +59,7 @@ impl<R: Runtime> ContractApi for Sandbox<R> {
         gas_limit: Weight,
     ) -> ContractExecResult<u128> {
         self.externalities.execute_with(|| {
-            Contracts::bare_call(
+            pallet_contracts::Pallet::<R>::bare_call(
                 origin,
                 address,
                 0,

--- a/drink/src/contract_api.rs
+++ b/drink/src/contract_api.rs
@@ -4,7 +4,10 @@ use frame_support::{sp_runtime::AccountId32, weights::Weight};
 use pallet_contracts::Determinism;
 use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult};
 
-use crate::{runtime::Contracts, Sandbox};
+use crate::{
+    runtime::{Contracts, Runtime},
+    Sandbox,
+};
 
 /// Interface for contract-related operations.
 pub trait ContractApi {
@@ -28,7 +31,7 @@ pub trait ContractApi {
     ) -> ContractExecResult<u128>;
 }
 
-impl ContractApi for Sandbox {
+impl<R: Runtime> ContractApi for Sandbox<R> {
     fn deploy_contract(
         &mut self,
         contract_bytes: Vec<u8>,

--- a/drink/src/error.rs
+++ b/drink/src/error.rs
@@ -9,4 +9,7 @@ pub enum Error {
     /// Block couldn't have been initialized.
     #[error("Failed to initialize block: {0}")]
     BlockInitialize(String),
+    /// Block couldn't have been finalized.
+    #[error("Failed to finalize block: {0}")]
+    BlockFinalize(String),
 }

--- a/drink/src/error.rs
+++ b/drink/src/error.rs
@@ -6,4 +6,7 @@ pub enum Error {
     /// Externalities could not be initialized.
     #[error("Failed to build storage: {0}")]
     StorageBuilding(String),
+    /// Block couldn't have been initialized.
+    #[error("Failed to initialize block: {0}")]
+    BlockInitialize(String),
 }

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -6,14 +6,14 @@
 pub mod chain_api;
 pub mod contract_api;
 mod error;
-mod runtime;
+pub mod runtime;
 #[cfg(feature = "session")]
 pub mod session;
 
-use std::{marker::PhantomData, time::SystemTime};
+use std::marker::PhantomData;
 
 pub use error::Error;
-use frame_support::{sp_io::TestExternalities, traits::Hooks};
+use frame_support::sp_io::TestExternalities;
 pub use frame_support::{sp_runtime::AccountId32, weights::Weight};
 use frame_system::GenesisConfig;
 

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -51,14 +51,12 @@ impl<R: Runtime> Sandbox<R> {
             externalities: TestExternalities::new(storage),
             _phantom: PhantomData,
         };
-        sandbox.init_block(0)?;
-        Ok(sandbox)
-    }
 
-    /// Does the block initialization work.
-    fn init_block(&mut self, height: u64) -> DrinkResult<()> {
-        self.externalities
-            .execute_with(|| R::initialize_block(height))
-            .map_err(Error::BlockInitialize)
+        sandbox
+            .externalities
+            .execute_with(|| R::initialize_block(0, Default::default()))
+            .map_err(Error::BlockInitialize)?;
+
+        Ok(sandbox)
     }
 }

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -10,11 +10,11 @@ use frame_support::{
 };
 use pallet_contracts::{DefaultAddressGenerator, Frame, Schedule};
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<SandboxRuntime>;
-type Block = frame_system::mocking::MockBlock<SandboxRuntime>;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<MinimalRuntime>;
+type Block = frame_system::mocking::MockBlock<MinimalRuntime>;
 
 frame_support::construct_runtime!(
-    pub enum SandboxRuntime where
+    pub enum MinimalRuntime where
         Block = Block,
         NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic,
@@ -26,7 +26,7 @@ frame_support::construct_runtime!(
     }
 );
 
-impl frame_system::Config for SandboxRuntime {
+impl frame_system::Config for MinimalRuntime {
     type BaseCallFilter = frame_support::traits::Everything;
     type BlockWeights = ();
     type BlockLength = ();
@@ -53,7 +53,7 @@ impl frame_system::Config for SandboxRuntime {
     type MaxConsumers = ConstU32<16>;
 }
 
-impl pallet_balances::Config for SandboxRuntime {
+impl pallet_balances::Config for MinimalRuntime {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
     type Balance = u128;
@@ -69,7 +69,7 @@ impl pallet_balances::Config for SandboxRuntime {
     type MaxFreezes = ();
 }
 
-impl pallet_timestamp::Config for SandboxRuntime {
+impl pallet_timestamp::Config for MinimalRuntime {
     type Moment = u64;
     type OnTimestampSet = ();
     type MinimumPeriod = ConstU64<1>;
@@ -84,20 +84,20 @@ impl Randomness<H256, u64> for SandboxRandomness {
 }
 
 type BalanceOf = <Balances as Currency<AccountId32>>::Balance;
-impl Convert<Weight, BalanceOf> for SandboxRuntime {
+impl Convert<Weight, BalanceOf> for MinimalRuntime {
     fn convert(w: Weight) -> BalanceOf {
         w.ref_time().into()
     }
 }
 
 parameter_types! {
-    pub SandboxSchedule: Schedule<SandboxRuntime> = {
-        <Schedule<SandboxRuntime>>::default()
+    pub SandboxSchedule: Schedule<MinimalRuntime> = {
+        <Schedule<MinimalRuntime>>::default()
     };
     pub DeletionWeightLimit: Weight = Weight::zero();
 }
 
-impl pallet_contracts::Config for SandboxRuntime {
+impl pallet_contracts::Config for MinimalRuntime {
     type Time = Timestamp;
     type Randomness = SandboxRandomness;
     type Currency = Balances;

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)] // `construct_macro` doesn't allow doc comments for the runtime type.
+
 use frame_support::{
     parameter_types,
     sp_runtime::{

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -6,8 +6,6 @@ mod minimal;
 use frame_support::sp_runtime::{AccountId32, Storage};
 pub use minimal::MinimalRuntime;
 
-use super::DEFAULT_ACTOR;
-
 /// A runtime to use.
 ///
 /// Must contain at least system, balances and contracts pallets.
@@ -22,23 +20,15 @@ pub trait Runtime:
     }
 
     /// Initialize a new block at particular height.
-    fn initialize_block(_height: u64) -> Result<(), String> {
+    fn initialize_block(
+        _height: u64,
+        _parent_hash: <Self as frame_system::Config>::Hash,
+    ) -> Result<(), String> {
         Ok(())
     }
-}
 
-/// Default initial balance for the default account.
-pub const INITIAL_BALANCE: u128 = 1_000_000_000_000_000;
-
-impl Runtime for MinimalRuntime {
-    fn initialize_storage(storage: &mut Storage) -> Result<(), String> {
-        pallet_balances::GenesisConfig::<Self> {
-            balances: vec![(DEFAULT_ACTOR, INITIAL_BALANCE)],
-        }
-        .assimilate_storage(storage)
-    }
-
-    fn initialize_block(_: u64) -> Result<(), String> {
-        todo!()
+    /// Finalize a block at particular height.
+    fn finalize_block(_height: u64) -> Result<<Self as frame_system::Config>::Hash, String> {
+        Ok(Default::default())
     }
 }

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -1,8 +1,10 @@
+//! Module containing the [`Runtime`](Runtime) trait and its example implementations. You can use
+//! `drink` with any runtime that implements the `Runtime` trait.
+
 mod minimal;
 
-use frame_support::sp_runtime::Storage;
+use frame_support::sp_runtime::{AccountId32, Storage};
 pub use minimal::MinimalRuntime;
-use minimal::*;
 
 use super::DEFAULT_ACTOR;
 
@@ -10,13 +12,16 @@ use super::DEFAULT_ACTOR;
 ///
 /// Must contain at least system, balances and contracts pallets.
 pub trait Runtime:
-    frame_system::Config + pallet_balances::Config + pallet_contracts::Config
+    frame_system::Config<AccountId = AccountId32, BlockNumber = u64>
+    + pallet_balances::Config<Balance = u128>
+    + pallet_contracts::Config<Currency = pallet_balances::Pallet<Self>>
 {
     /// Initialize the storage at the genesis block.
-    fn initialize_storage(storage: &mut Storage) -> Result<(), String> {
+    fn initialize_storage(_storage: &mut Storage) -> Result<(), String> {
         Ok(())
     }
 
+    /// Initialize a new block at particular height.
     fn initialize_block(_height: u64) -> Result<(), String> {
         Ok(())
     }
@@ -30,7 +35,7 @@ impl Runtime for MinimalRuntime {
         pallet_balances::GenesisConfig::<Self> {
             balances: vec![(DEFAULT_ACTOR, INITIAL_BALANCE)],
         }
-        .assimilate_storage(&mut storage)
+        .assimilate_storage(storage)
     }
 
     fn initialize_block(_: u64) -> Result<(), String> {

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -1,0 +1,39 @@
+mod minimal;
+
+use frame_support::sp_runtime::Storage;
+pub use minimal::MinimalRuntime;
+use minimal::*;
+
+use super::DEFAULT_ACTOR;
+
+/// A runtime to use.
+///
+/// Must contain at least system, balances and contracts pallets.
+pub trait Runtime:
+    frame_system::Config + pallet_balances::Config + pallet_contracts::Config
+{
+    /// Initialize the storage at the genesis block.
+    fn initialize_storage(storage: &mut Storage) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn initialize_block(_height: u64) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+/// Default initial balance for the default account.
+pub const INITIAL_BALANCE: u128 = 1_000_000_000_000_000;
+
+impl Runtime for MinimalRuntime {
+    fn initialize_storage(storage: &mut Storage) -> Result<(), String> {
+        pallet_balances::GenesisConfig::<Self> {
+            balances: vec![(DEFAULT_ACTOR, INITIAL_BALANCE)],
+        }
+        .assimilate_storage(&mut storage)
+    }
+
+    fn initialize_block(_: u64) -> Result<(), String> {
+        todo!()
+    }
+}

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -64,7 +64,10 @@ pub enum SessionError {
 /// # fn bob() -> AccountId32 { AccountId32::new([0; 32]) }
 ///
 /// # fn main() -> Result<(), drink::session::SessionError> {
-/// Session::new(Some(get_transcoder()))?
+///
+/// use drink::runtime::MinimalRuntime;
+///
+/// Session::<MinimalRuntime>::new(Some(get_transcoder()))?
 ///     .deploy_and(contract_bytes(), "new", &[], vec![])?
 ///     .call_and("foo", &[])?
 ///     .with_actor(bob())
@@ -86,7 +89,9 @@ pub enum SessionError {
 /// # fn bob() -> AccountId32 { AccountId32::new([0; 32]) }
 ///
 /// # fn main() -> Result<(), drink::session::SessionError> {
-/// let mut session = Session::new(Some(get_transcoder()))?;
+/// use drink::runtime::MinimalRuntime;
+///
+/// let mut session = Session::<MinimalRuntime>::new(Some(get_transcoder()))?;
 /// let _address = session.deploy(contract_bytes(), "new", &[], vec![])?;
 /// session.call("foo", &[])?;
 /// session.set_actor(bob());

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -9,7 +9,8 @@ use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult}
 use thiserror::Error;
 
 use crate::{
-    chain_api::ChainApi, contract_api::ContractApi, Sandbox, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT,
+    chain_api::ChainApi, contract_api::ContractApi, runtime::Runtime, Sandbox, DEFAULT_ACTOR,
+    DEFAULT_GAS_LIMIT,
 };
 
 /// Session specific errors.
@@ -92,8 +93,8 @@ pub enum SessionError {
 /// session.call("bar", &[])?;
 /// # Ok(()) }
 /// ```
-pub struct Session {
-    sandbox: Sandbox,
+pub struct Session<R: Runtime> {
+    sandbox: Sandbox<R>,
 
     actor: AccountId32,
     gas_limit: Weight,
@@ -106,7 +107,7 @@ pub struct Session {
     call_returns: Vec<Value>,
 }
 
-impl Session {
+impl<R: Runtime> Session<R> {
     /// Creates a new `Session` with optional reference to a transcoder.
     pub fn new(transcoder: Option<Rc<ContractMessageTranscoder>>) -> Result<Self, SessionError> {
         Ok(Self {

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -34,9 +34,12 @@ mod flipper {
 mod tests {
     use std::{error::Error, fs, path::PathBuf, rc::Rc};
 
-    use drink::session::{
-        contract_transcode::{ContractMessageTranscoder, Tuple, Value},
-        Session,
+    use drink::{
+        runtime::MinimalRuntime,
+        session::{
+            contract_transcode::{ContractMessageTranscoder, Tuple, Value},
+            Session,
+        },
     };
 
     fn transcoder() -> Option<Rc<ContractMessageTranscoder>> {
@@ -56,7 +59,7 @@ mod tests {
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::new(transcoder())?
+        let init_value = Session::<MinimalRuntime>::new(transcoder())?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
             .call_and("get", &[])?
             .last_call_return()
@@ -69,7 +72,7 @@ mod tests {
 
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::new(transcoder())?
+        let init_value = Session::<MinimalRuntime>::new(transcoder())?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
             .call_and("flip", &[])?
             .call_and("flip", &[])?


### PR DESCRIPTION
1. We abstract `Sandbox` and `Session` to be generic over underlying runtime.
2. We provide the `Runtime` trait that captures minimal requirements (three necessary pallets, few basic types). Some of them might be relaxed further, but it's not necessary now and would introduce denser type-soup.
3. We provide implementation for `MinimalRuntime` and instantiate `drink-cli` with it