### PR TITLE
Missing explicit drink version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ sp-core = { version = "20.0.0" }
 
 # Local dependencies
 
-drink = { path = "drink" }
+drink = { version = "0.1.0", path = "drink" }


### PR DESCRIPTION
required for publishing `drink-cli` crate