### PR TITLE
Call runtime

### DIFF
--- a/drink/src/chain_api.rs
+++ b/drink/src/chain_api.rs
@@ -57,6 +57,7 @@ pub trait ChainApi<R: Runtime> {
     /// # Arguments
     ///
     /// * `call` - The runtime call to execute.
+    /// * `origin` - The origin of the call.
     fn runtime_call(
         &mut self,
         call: RuntimeCall<R>,

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -164,7 +164,7 @@ impl<R: Runtime> Session<R> {
     }
 
     /// Returns a reference for basic chain API.
-    pub fn chain_api(&mut self) -> &mut impl ChainApi {
+    pub fn chain_api(&mut self) -> &mut impl ChainApi<R> {
         &mut self.sandbox
     }
 


### PR DESCRIPTION
closes #36 

While the current solution is quite clean, its usage might turn out to be onerous (the vanilla way is to have a target pallet as a dependency). However, one can always prepare the object call manually without pallet (e.g. with subxt), encode it and then decode it :shrug: 

This problem will rise in ink! integration, where we have to implement:
```rust 
fn runtime_call<'a>(
        &mut self,
        _origin: &Keypair,
        _pallet_name: &'a str,
        _call_name: &'a str,
        _call_data: Vec<Value>,
    )
```

where `Value` comes from `subxt`. For this however, I will try to change the API there a bit (it was designed for subxt only). Then, integration with this new code should be much easier.