### PR TITLE
Use dedicated pallet crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
- "pallet-contracts",
+ "pallet-contracts-for-drink",
  "pallet-contracts-primitives",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -2371,8 +2371,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-contracts"
-version = "4.0.0-dev"
+name = "pallet-contracts-for-drink"
+version = "21.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9f6abd1ee4a2d6e9702a45a646b87260cc9d36886b750496888454471cda69"
 dependencies = [
  "bitflags",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,9 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3646037567a1402b6a4b3b8e4777c41f570bca94b2941f00e6f0bfec75f77646"
+version = "4.0.0-dev"
 dependencies = [
  "bitflags",
  "environmental",
@@ -3254,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "sp-api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ wat = { version = "1.0.71" }
 frame-support = { version = "22.0.0" }
 frame-system = { version = "22.0.0" }
 pallet-balances = { version = "22.0.0" }
-pallet-contracts-for-drink = { version = "21.0.1" }
+pallet-contracts = { package = "pallet-contracts-for-drink", version = "21.0.1" }
 pallet-contracts-primitives = { version = "25.0.0" }
 pallet-timestamp = { version = "21.0.0" }
 sp-core = { version = "22.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ wat = { version = "1.0.71" }
 frame-support = { version = "22.0.0" }
 frame-system = { version = "22.0.0" }
 pallet-balances = { version = "22.0.0" }
-pallet-contracts = { version = "21.0.0" }
+pallet-contracts-for-drink = { version = "21.0.1" }
 pallet-contracts-primitives = { version = "25.0.0" }
 pallet-timestamp = { version = "21.0.0" }
 sp-core = { version = "22.0.0" }

--- a/drink/Cargo.toml
+++ b/drink/Cargo.toml
@@ -14,7 +14,7 @@ contract-transcode = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-balances = { workspace = true }
-pallet-contracts = { workspace = true }
+pallet-contracts = { package = "pallet-contracts-for-drink", workspace = true }
 pallet-contracts-primitives = { workspace = true }
 pallet-timestamp = { workspace = true }
 parity-scale-codec = { workspace = true }

--- a/drink/Cargo.toml
+++ b/drink/Cargo.toml
@@ -14,7 +14,7 @@ contract-transcode = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-balances = { workspace = true }
-pallet-contracts = { package = "pallet-contracts-for-drink", workspace = true }
+pallet-contracts = { workspace = true }
 pallet-contracts-primitives = { workspace = true }
 pallet-timestamp = { workspace = true }
 parity-scale-codec = { workspace = true }

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -121,6 +121,7 @@ impl pallet_contracts::Config for MinimalRuntime {
     type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
     type Migrations = ();
     type DefaultDepositLimit = DefaultDepositLimit;
+    type Debug = ();
 }
 
 use std::time::SystemTime;


### PR DESCRIPTION
There are some incoming features that require support in pallet contracts. Since release process of Substrate crates is still not fully developed nor very frequent, for now we will use dedicated crate, which will include required support, but stay compatible with the rest dependencies.