### PR TITLE
Cross-contract call tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-for-drink"
-version = "21.0.2"
+version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1071ed81959cbc593389d0f000fe6dbc7b1726af1c1580df162a6e94d0d0cb"
+checksum = "e73bc2df30641c195d3be0a105548a3f0cc4f250c9de7d24d4c51fc43d8c3ef4"
 dependencies = [
  "bitflags",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-for-drink"
-version = "21.0.1"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9f6abd1ee4a2d6e9702a45a646b87260cc9d36886b750496888454471cda69"
+checksum = "5f1071ed81959cbc593389d0f000fe6dbc7b1726af1c1580df162a6e94d0d0cb"
 dependencies = [
  "bitflags",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,8 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
+ "sp-externalities",
+ "sp-runtime-interface",
  "thiserror",
  "wat",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 exclude = [
     "examples/counter",
     "examples/flipper",
+    "examples/cross-contract-call-tracing",
 ]
 
 [workspace.package]
@@ -37,7 +38,7 @@ wat = { version = "1.0.71" }
 frame-support = { version = "22.0.0" }
 frame-system = { version = "22.0.0" }
 pallet-balances = { version = "22.0.0" }
-pallet-contracts = { package = "pallet-contracts-for-drink", version = "21.0.1" }
+pallet-contracts = { package = "pallet-contracts-for-drink", version = "21.0.2" }
 pallet-contracts-primitives = { version = "25.0.0" }
 pallet-timestamp = { version = "21.0.0" }
 sp-core = { version = "22.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ wat = { version = "1.0.71" }
 frame-support = { version = "22.0.0" }
 frame-system = { version = "22.0.0" }
 pallet-balances = { version = "22.0.0" }
-pallet-contracts = { package = "pallet-contracts-for-drink", version = "21.0.2" }
+pallet-contracts = { package = "pallet-contracts-for-drink", version = "21.0.3" }
 pallet-contracts-primitives = { version = "25.0.0" }
 pallet-timestamp = { version = "21.0.0" }
 sp-core = { version = "22.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ pallet-contracts = { package = "pallet-contracts-for-drink", version = "21.0.2" 
 pallet-contracts-primitives = { version = "25.0.0" }
 pallet-timestamp = { version = "21.0.0" }
 sp-core = { version = "22.0.0" }
+sp-externalities = { version = "0.20.0" }
+sp-runtime-interface = { version = "18.0.0" }
 
 # Local dependencies
 

--- a/drink/Cargo.toml
+++ b/drink/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 wat = { workspace = true }
 
 [features]
+# This is required for the runtime-interface to work properly in the std env.
 default = ["std"]
 session = ["contract-transcode"]
 std = []

--- a/drink/Cargo.toml
+++ b/drink/Cargo.toml
@@ -18,6 +18,9 @@ pallet-contracts = { workspace = true }
 pallet-contracts-primitives = { workspace = true }
 pallet-timestamp = { workspace = true }
 parity-scale-codec = { workspace = true }
+sp-externalities = { workspace = true }
+sp-runtime-interface = { workspace = true }
+
 scale-info = { workspace = true }
 thiserror = { workspace = true }
 
@@ -25,4 +28,6 @@ thiserror = { workspace = true }
 wat = { workspace = true }
 
 [features]
+default = ["std"]
 session = ["contract-transcode"]
+std = []

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -17,6 +17,7 @@ pub use frame_support::{sp_runtime::AccountId32, weights::Weight};
 use frame_system::{EventRecord, GenesisConfig};
 
 use crate::pallet_contracts_debugging::DebugExt;
+use crate::runtime::pallet_contracts_debugging::NoopDebugExt;
 use crate::runtime::*;
 
 /// Main result type for the drink crate.
@@ -63,10 +64,12 @@ impl<R: Runtime> Sandbox<R> {
             .execute_with(|| R::initialize_block(1, Default::default()))
             .map_err(Error::BlockInitialize)?;
 
+        sandbox.override_debug_handle(DebugExt(Box::new(NoopDebugExt {})));
+
         Ok(sandbox)
     }
 
-    pub fn register_debug_handle(&mut self, d: DebugExt) {
+    pub fn override_debug_handle(&mut self, d: DebugExt) {
         self.externalities.register_extension(d);
     }
 }

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -64,11 +64,16 @@ impl<R: Runtime> Sandbox<R> {
             .execute_with(|| R::initialize_block(1, Default::default()))
             .map_err(Error::BlockInitialize)?;
 
+        // We register a noop debug extension by default.
         sandbox.override_debug_handle(DebugExt(Box::new(NoopDebugExt {})));
 
         Ok(sandbox)
     }
 
+    /// Overrides the debug extension.
+    ///
+    /// By default, a new `Sandbox` instance is created with a noop debug extension. This method
+    /// allows to override it with a custom debug extension.
     pub fn override_debug_handle(&mut self, d: DebugExt) {
         self.externalities.register_extension(d);
     }

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -16,6 +16,7 @@ use frame_support::{sp_io::TestExternalities, sp_runtime::BuildStorage};
 pub use frame_support::{sp_runtime::AccountId32, weights::Weight};
 use frame_system::{EventRecord, GenesisConfig};
 
+use crate::pallet_contracts_debugging::DebugExt;
 use crate::runtime::*;
 
 /// Main result type for the drink crate.
@@ -63,5 +64,9 @@ impl<R: Runtime> Sandbox<R> {
             .map_err(Error::BlockInitialize)?;
 
         Ok(sandbox)
+    }
+
+    pub fn register_debug_handle(&mut self, d: DebugExt) {
+        self.externalities.register_extension(d);
     }
 }

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -1,22 +1,25 @@
 #![allow(missing_docs)] // `construct_macro` doesn't allow doc comments for the runtime type.
 
+use std::time::SystemTime;
+
 use frame_support::{
     parameter_types,
     sp_runtime::{
         testing::H256,
         traits::{BlakeTwo256, Convert, IdentityLookup},
-        AccountId32, BuildStorage,
+        AccountId32, BuildStorage, Storage,
     },
-    traits::{ConstBool, ConstU128, ConstU32, ConstU64, Currency, Randomness},
+    traits::{ConstBool, ConstU128, ConstU32, ConstU64, Currency, Hooks, Randomness},
     weights::Weight,
 };
-use pallet_contracts::{DefaultAddressGenerator, Frame, Schedule};
-
 // Re-export all pallets.
 pub use frame_system;
 pub use pallet_balances;
 pub use pallet_contracts;
+use pallet_contracts::{DefaultAddressGenerator, Frame, Schedule};
 pub use pallet_timestamp;
+
+use crate::{runtime::pallet_contracts_debugging::DrinkDebug, Runtime, DEFAULT_ACTOR};
 
 type Block = frame_system::mocking::MockBlock<MinimalRuntime>;
 
@@ -121,14 +124,8 @@ impl pallet_contracts::Config for MinimalRuntime {
     type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
     type Migrations = ();
     type DefaultDepositLimit = DefaultDepositLimit;
-    type Debug = ();
+    type Debug = DrinkDebug;
 }
-
-use std::time::SystemTime;
-
-use frame_support::{sp_runtime::Storage, traits::Hooks};
-
-use crate::{Runtime, DEFAULT_ACTOR};
 
 /// Default initial balance for the default account.
 pub const INITIAL_BALANCE: u128 = 1_000_000_000_000_000;

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -2,6 +2,7 @@
 //! `drink` with any runtime that implements the `Runtime` trait.
 
 pub mod minimal;
+pub mod pallet_contracts_debugging;
 
 use frame_support::sp_runtime::{AccountId32, Storage};
 pub use minimal::MinimalRuntime;

--- a/drink/src/runtime/pallet_contracts_debugging.rs
+++ b/drink/src/runtime/pallet_contracts_debugging.rs
@@ -1,9 +1,34 @@
 use pallet_contracts::debug::{CallSpan, ExportedFunction, Tracing};
 use pallet_contracts_primitives::ExecReturnValue;
+use sp_externalities::{decl_extension, ExternalitiesExt};
+use sp_runtime_interface::runtime_interface;
 
 use crate::runtime::Runtime;
 
 type CodeHash<R> = <R as frame_system::Config>::Hash;
+
+pub trait DebugExtT {
+    fn after_call(&self, code_hash: Vec<u8>, is_call: bool, input_data: Vec<u8>, result: Vec<u8>);
+}
+
+decl_extension! {
+    pub struct DebugExt(Box<dyn DebugExtT + Send>);
+}
+
+#[runtime_interface]
+pub trait ContractCallDebugger {
+    fn after_call(
+        &mut self,
+        code_hash: Vec<u8>,
+        is_call: bool,
+        input_data: Vec<u8>,
+        result: Vec<u8>,
+    ) {
+        self.extension::<DebugExt>()
+            .expect("Failed to find `DebugExt` extension")
+            .after_call(code_hash, is_call, input_data, result);
+    }
+}
 
 pub enum DrinkDebug {}
 
@@ -29,8 +54,14 @@ pub struct DrinkCallSpan<CodeHash> {
     pub input_data: Vec<u8>,
 }
 
-impl<CodeHash> CallSpan for DrinkCallSpan<CodeHash> {
+impl<CodeHash: AsRef<[u8]>> CallSpan for DrinkCallSpan<CodeHash> {
     fn after_call(self, output: &ExecReturnValue) {
-        todo!()
+        let raw_code_hash: &[u8] = self.code_hash.as_ref();
+        contract_call_debugger::after_call(
+            raw_code_hash.to_vec(),
+            matches!(self.entry_point, ExportedFunction::Call),
+            self.input_data.to_vec(),
+            output.data.clone(),
+        );
     }
 }

--- a/drink/src/runtime/pallet_contracts_debugging.rs
+++ b/drink/src/runtime/pallet_contracts_debugging.rs
@@ -1,0 +1,36 @@
+use pallet_contracts::debug::{CallSpan, ExportedFunction, Tracing};
+use pallet_contracts_primitives::ExecReturnValue;
+
+use crate::runtime::Runtime;
+
+type CodeHash<R> = <R as frame_system::Config>::Hash;
+
+pub enum DrinkDebug {}
+
+impl<R: Runtime> Tracing<R> for DrinkDebug {
+    type CallSpan = DrinkCallSpan<CodeHash<R>>;
+
+    fn new_call_span(
+        code_hash: &CodeHash<R>,
+        entry_point: ExportedFunction,
+        input_data: &[u8],
+    ) -> Self::CallSpan {
+        DrinkCallSpan {
+            code_hash: *code_hash,
+            entry_point,
+            input_data: input_data.to_vec(),
+        }
+    }
+}
+
+pub struct DrinkCallSpan<CodeHash> {
+    pub code_hash: CodeHash,
+    pub entry_point: ExportedFunction,
+    pub input_data: Vec<u8>,
+}
+
+impl<CodeHash> CallSpan for DrinkCallSpan<CodeHash> {
+    fn after_call(self, output: &ExecReturnValue) {
+        todo!()
+    }
+}

--- a/drink/src/runtime/pallet_contracts_debugging.rs
+++ b/drink/src/runtime/pallet_contracts_debugging.rs
@@ -17,8 +17,8 @@
 //! # Passing objects between runtime and runtime extension
 //!
 //! Unfortunately, runtime interface that lies between runtime and the end-user accepts only
-//! very simlpe argument types and those that implement some specific traits. This means that
-//! usually, complext objects will be passed in their encoded form (`Vec<u8>` obtained with scale
+//! very simple argument types and those that implement some specific traits. This means that
+//! usually, complex objects will be passed in their encoded form (`Vec<u8>` obtained with scale
 //! encoding).
 
 use pallet_contracts::debug::{CallSpan, ExportedFunction, Tracing};

--- a/drink/src/runtime/pallet_contracts_debugging.rs
+++ b/drink/src/runtime/pallet_contracts_debugging.rs
@@ -8,12 +8,15 @@ use crate::runtime::Runtime;
 type CodeHash<R> = <R as frame_system::Config>::Hash;
 
 pub trait DebugExtT {
-    fn after_call(&self, code_hash: Vec<u8>, is_call: bool, input_data: Vec<u8>, result: Vec<u8>);
+    fn after_call(&self, code_hash: Vec<u8>, is_call: bool, input_data: Vec<u8>, result: Vec<u8>) {}
 }
 
 decl_extension! {
     pub struct DebugExt(Box<dyn DebugExtT + Send>);
 }
+
+pub struct NoopDebugExt {}
+impl DebugExtT for NoopDebugExt {}
 
 #[runtime_interface]
 pub trait ContractCallDebugger {

--- a/drink/src/runtime/pallet_contracts_debugging.rs
+++ b/drink/src/runtime/pallet_contracts_debugging.rs
@@ -8,7 +8,14 @@ use crate::runtime::Runtime;
 type AccountIdOf<R> = <R as frame_system::Config>::AccountId;
 
 pub trait DebugExtT {
-    fn after_call(&self, code_hash: Vec<u8>, is_call: bool, input_data: Vec<u8>, result: Vec<u8>) {}
+    fn after_call(
+        &self,
+        contract_address: Vec<u8>,
+        is_call: bool,
+        input_data: Vec<u8>,
+        result: Vec<u8>,
+    ) {
+    }
 }
 
 decl_extension! {

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -9,8 +9,8 @@ use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult}
 use thiserror::Error;
 
 use crate::{
-    chain_api::ChainApi, contract_api::ContractApi, runtime::Runtime, AccountId32, EventRecordOf,
-    Sandbox, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT,
+    chain_api::ChainApi, contract_api::ContractApi, pallet_contracts_debugging::DebugExt,
+    runtime::Runtime, AccountId32, EventRecordOf, Sandbox, DEFAULT_ACTOR, DEFAULT_GAS_LIMIT,
 };
 
 const ZERO_TRANSFER: u128 = 0;
@@ -331,5 +331,9 @@ impl<R: Runtime> Session<R> {
     /// Returns the last value returned from calling a contract.
     pub fn last_call_return(&self) -> Option<Value> {
         self.call_returns.last().cloned()
+    }
+
+    pub fn override_debug_handle(&mut self, d: DebugExt) {
+        self.sandbox.override_debug_handle(d);
     }
 }

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -333,6 +333,10 @@ impl<R: Runtime> Session<R> {
         self.call_returns.last().cloned()
     }
 
+    /// Overrides the debug extension.
+    ///
+    /// By default, a new `Session` instance will use a noop debug extension. This method allows to
+    /// override it with a custom debug extension.
     pub fn override_debug_handle(&mut self, d: DebugExt) {
         self.sandbox.override_debug_handle(d);
     }

--- a/examples/cross-contract-call-tracing/Cargo.toml
+++ b/examples/cross-contract-call-tracing/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "cross-contract-call-tracing"
+authors = ["Cardinal"]
+edition = "2021"
+homepage = "https://alephzero.org"
+repository = "https://github.com/Cardinal-Cryptography/drink"
+version = "0.1.0"
+
+[dependencies]
+ink = { version = "=4.2.1", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+drink = { path = "../../drink", features = ["session"] }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []

--- a/examples/cross-contract-call-tracing/README.md
+++ b/examples/cross-contract-call-tracing/README.md
@@ -1,0 +1,60 @@
+# Cross contract call tracing
+
+This example shows how you can trace and debug cross contract calls.
+
+## Scenario
+
+Here we have a single contract with 3 methods:
+ - `call_inner(arg: u32)`: returns the result of some simple computation on `arg`
+ - `call_middle(next_callee: AccountId, arg: u32)`: calls `call_inner(arg)` at `next_callee` and forwards the result
+ - `call_outer(next_callee: AccountId, next_next_callee: AccountId, arg: u32)`: calls `call_middle(next_next_callee, arg)` at `next_callee` and forwards the result
+
+We deploy three instances of this contract, `inner`, `middle` and `outer`, and call `call_outer` on `outer` with `inner` and `middle` and some integer as arguments.
+
+If we were using just `cargo-contract` or some other tooling, we would be able to see only the final result of the call.
+However, it wouldn't be possible to trace the intermediate steps.
+With `drink`, we can provide handlers for (synchronous) observing every level of the call stack.
+
+## Running
+
+```bash
+cargo contract build --release
+cargo test --release -- --show-output
+```
+
+You should be able to see similar output:
+```
+Contract at address `5CmHh6aBH6YZLjHGHjVtDDU4PfvDvk9s8n5xAcZQajxikksr` has been called with data: 
+    new
+and returned:
+    ()
+
+Contract at address `5FNvS4rLX8Y5NotoRzyBpmeNq2cfcSRpBWbHvgNrEiY3ero7` has been called with data: 
+    new
+and returned:
+    ()
+
+Contract at address `5DhNNsxhPMhg8R7StY3LbHraQWTDRFEbK2C1CaAD2AGvDCAf` has been called with data: 
+    new
+and returned:
+    ()
+
+Contract at address `5DhNNsxhPMhg8R7StY3LbHraQWTDRFEbK2C1CaAD2AGvDCAf` has been called with data: 
+    inner_call { arg: 7 }
+and returned:
+    Ok(22)
+
+Contract at address `5FNvS4rLX8Y5NotoRzyBpmeNq2cfcSRpBWbHvgNrEiY3ero7` has been called with data: 
+    middle_call { next_callee: 5DhNNsxhPMhg8R7StY3LbHraQWTDRFEbK2C1CaAD2AGvDCAf, arg: 7 }
+and returned:
+    Ok(22)
+
+Contract at address `5CmHh6aBH6YZLjHGHjVtDDU4PfvDvk9s8n5xAcZQajxikksr` has been called with data: 
+    outer_call { next_callee: 5FNvS4rLX8Y5NotoRzyBpmeNq2cfcSRpBWbHvgNrEiY3ero7, next_next_callee: 5DhNNsxhPMhg8R7StY3LbHraQWTDRFEbK2C1CaAD2AGvDCAf, arg: 7 }
+and returned:
+    Ok(22)
+
+
+successes:
+    tests::test
+```

--- a/examples/cross-contract-call-tracing/lib.rs
+++ b/examples/cross-contract-call-tracing/lib.rs
@@ -59,3 +59,94 @@ mod contract {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ink::storage::traits::Storable;
+    use std::{error::Error, fs, path::PathBuf, rc::Rc};
+
+    use drink::{
+        runtime::{
+            pallet_contracts_debugging::{DebugExt, DebugExtT},
+            MinimalRuntime,
+        },
+        session::{
+            contract_transcode::{ContractMessageTranscoder, Tuple, Value},
+            Session,
+        },
+        AccountId32,
+    };
+
+    fn transcoder() -> Rc<ContractMessageTranscoder> {
+        let path = PathBuf::from("target/ink/cross_contract_call_tracing.json");
+        Rc::new(ContractMessageTranscoder::load(path).expect("Failed to create transcoder"))
+    }
+
+    fn bytes() -> Vec<u8> {
+        let path = "target/ink/cross_contract_call_tracing.wasm";
+        fs::read(path).expect("Failed to find or read contract file")
+    }
+
+    fn ok(v: Value) -> Value {
+        Value::Tuple(Tuple::new(Some("Ok"), vec![v]))
+    }
+
+    struct TestDebugger;
+    impl DebugExtT for TestDebugger {
+        fn after_call(
+            &self,
+            contract_address: Vec<u8>,
+            is_call: bool,
+            input_data: Vec<u8>,
+            result: Vec<u8>,
+        ) {
+            let contract_address = AccountId32::decode(&mut contract_address.as_slice())
+                .expect("Failed to decode contract address");
+            let transcoder = transcoder();
+
+            let data_decoded = if is_call {
+                transcoder.decode_contract_message(&mut input_data.as_slice())
+            } else {
+                transcoder.decode_contract_constructor(&mut input_data.as_slice())
+            }
+            .unwrap();
+
+            let return_decoded = if is_call {
+                transcoder
+                    .decode_return("outer_call", &mut result.as_slice())
+                    .unwrap()
+            } else {
+                Value::Unit
+            };
+
+            println!(
+                "Contract at address `{contract_address}` has been called with data: \
+                    \n    {data_decoded}\nand returned:\n    {return_decoded}\n"
+            )
+        }
+    }
+
+    #[test]
+    fn test() -> Result<(), Box<dyn Error>> {
+        let mut session = Session::<MinimalRuntime>::new(Some(transcoder()))?;
+        session.override_debug_handle(DebugExt(Box::new(TestDebugger {})));
+
+        let outer_address = session.deploy(bytes(), "new", &[], vec![1])?;
+        let middle_address = session.deploy(bytes(), "new", &[], vec![2])?;
+        let inner_address = session.deploy(bytes(), "new", &[], vec![3])?;
+
+        let value = session.call_with_address(
+            outer_address,
+            "outer_call",
+            &[
+                middle_address.to_string(),
+                inner_address.to_string(),
+                "7".to_string(),
+            ],
+        )?;
+
+        assert_eq!(value, ok(Value::UInt(22)));
+
+        Ok(())
+    }
+}

--- a/examples/cross-contract-call-tracing/lib.rs
+++ b/examples/cross-contract-call-tracing/lib.rs
@@ -1,0 +1,61 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod contract {
+    use ink::env::{
+        call::{build_call, ExecutionInput, Selector},
+        DefaultEnvironment,
+    };
+
+    #[ink(storage)]
+    pub struct CrossCallingContract;
+
+    impl CrossCallingContract {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn outer_call(
+            &self,
+            next_callee: AccountId,
+            next_next_callee: AccountId,
+            arg: u32,
+        ) -> u32 {
+            build_call::<DefaultEnvironment>()
+                .call(next_callee)
+                .gas_limit(0)
+                .transferred_value(0)
+                .exec_input(
+                    ExecutionInput::new(Selector::new(ink::selector_bytes!("middle_call")))
+                        .push_arg(next_next_callee)
+                        .push_arg(arg),
+                )
+                .returns::<u32>()
+                .invoke()
+        }
+
+        #[ink(message)]
+        pub fn middle_call(&self, next_callee: AccountId, arg: u32) -> u32 {
+            build_call::<DefaultEnvironment>()
+                .call(next_callee)
+                .gas_limit(0)
+                .transferred_value(0)
+                .exec_input(
+                    ExecutionInput::new(Selector::new(ink::selector_bytes!("inner_call")))
+                        .push_arg(arg),
+                )
+                .returns::<u32>()
+                .invoke()
+        }
+
+        #[ink(message)]
+        pub fn inner_call(&self, arg: u32) -> u32 {
+            match arg % 2 {
+                0 => arg / 2,
+                _ => 3 * arg + 1,
+            }
+        }
+    }
+}


### PR DESCRIPTION
We make use of the recent extension to pallet-contracts, which enables tracing cross-contract calls.