### PR TITLE
Minor extensions to the `Runtime` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "contract-transcode",
  "frame-support",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "drink-cli"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ clap = { version = "4.3.4" }
 contract-build = { version = "3.0.1" }
 contract-transcode = { version = "3.0.1" }
 crossterm = { version = "0.26.0" }
-parity-scale-codec = { version = "=3.6.5" }
-parity-scale-codec-derive = { version = "=3.6.5" }
+parity-scale-codec = { version = "3.4" }
+parity-scale-codec-derive = { version = "3.4" }
 ratatui = { version = "0.21.0" }
 scale-info = { version = "2.5.0" }
 thiserror = { version = "1.0.40" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.1.5"
+version = "0.1.6"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -48,4 +48,4 @@ sp-runtime-interface = { version = "18.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.1.5", path = "drink" }
+drink = { version = "0.1.6", path = "drink" }

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -2,8 +2,9 @@
 
 use std::time::SystemTime;
 
-use frame_support::metadata::RuntimeMetadataPrefixed;
 use frame_support::{
+    dispatch::Dispatchable,
+    metadata::RuntimeMetadataPrefixed,
     parameter_types,
     sp_runtime::{
         testing::H256,
@@ -15,7 +16,7 @@ use frame_support::{
 };
 // Re-export all pallets.
 pub use frame_system;
-use frame_system::pallet_prelude::BlockNumberFor;
+use frame_system::{pallet_prelude::BlockNumberFor, Config};
 pub use pallet_balances;
 pub use pallet_contracts;
 use pallet_contracts::{DefaultAddressGenerator, Frame, Schedule};
@@ -176,5 +177,11 @@ impl Runtime for MinimalRuntime {
 
     fn get_metadata() -> RuntimeMetadataPrefixed {
         Self::metadata()
+    }
+
+    fn convert_account_to_origin(
+        account: AccountIdFor<Self>,
+    ) -> <<Self as Config>::RuntimeCall as Dispatchable>::RuntimeOrigin {
+        Some(account).into()
     }
 }

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -2,6 +2,7 @@
 
 use std::time::SystemTime;
 
+use frame_support::metadata::RuntimeMetadataPrefixed;
 use frame_support::{
     parameter_types,
     sp_runtime::{
@@ -171,5 +172,9 @@ impl Runtime for MinimalRuntime {
 
     fn default_actor() -> AccountIdFor<Self> {
         AccountId32::new([1u8; 32])
+    }
+
+    fn get_metadata() -> RuntimeMetadataPrefixed {
+        Self::metadata()
     }
 }

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 pub mod minimal;
 pub mod pallet_contracts_debugging;
 
+use frame_support::metadata::RuntimeMetadataPrefixed;
 use frame_support::sp_runtime::Storage;
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use minimal::MinimalRuntime;
@@ -41,4 +42,7 @@ pub trait Runtime:
 
     /// Default actor for the runtime.
     fn default_actor() -> AccountIdFor<Self>;
+
+    /// Metadata of the runtime.
+    fn get_metadata() -> RuntimeMetadataPrefixed;
 }

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -4,8 +4,9 @@
 pub mod minimal;
 pub mod pallet_contracts_debugging;
 
-use frame_support::metadata::RuntimeMetadataPrefixed;
-use frame_support::sp_runtime::Storage;
+use frame_support::{
+    dispatch::Dispatchable, metadata::RuntimeMetadataPrefixed, sp_runtime::Storage,
+};
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use minimal::MinimalRuntime;
 
@@ -50,4 +51,9 @@ pub trait Runtime:
 
     /// Metadata of the runtime.
     fn get_metadata() -> RuntimeMetadataPrefixed;
+
+    /// Convert an account to an call origin.
+    fn convert_account_to_origin(
+        account: AccountIdFor<Self>,
+    ) -> <<Self as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin;
 }

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -12,6 +12,11 @@ pub use minimal::MinimalRuntime;
 /// The type of an account identifier.
 pub type AccountIdFor<R> = <R as frame_system::Config>::AccountId;
 
+/// Export pallets that are used in the runtime.
+pub use frame_system;
+pub use pallet_balances;
+pub use pallet_contracts;
+
 /// A runtime to use.
 ///
 /// Must contain at least system, balances and contracts pallets.


### PR DESCRIPTION
Required for ink! integration (https://github.com/paritytech/ink/pull/1892 is hanging on that)

Changes:
 - expose metadata through `Runtime` trait (previously it was only available for `MinimalRuntime`
 - stop pinning codec crates (the bugged ones has benn yanked)
 - expose conversion between account id and call origin in `Runtime` trait
 - export 3 critical pallet crates from `runtime` module