### PR TITLE
Accept any stringish arguments in session API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "contract-transcode",
  "frame-support",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "drink-cli"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.1.9"
+version = "0.2.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -48,4 +48,4 @@ sp-runtime-interface = { version = "18.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.1.9", path = "drink" }
+drink = { version = "0.2.0", path = "drink" }

--- a/drink/src/contract_api.rs
+++ b/drink/src/contract_api.rs
@@ -6,12 +6,12 @@ use pallet_contracts::{CollectEvents, DebugInfo, Determinism};
 use pallet_contracts_primitives::{
     Code, CodeUploadResult, ContractExecResult, ContractInstantiateResult,
 };
+use parity_scale_codec::Decode as _;
 
 use crate::{
     runtime::{AccountIdFor, Runtime},
     EventRecordOf, Sandbox,
 };
-use parity_scale_codec::Decode as _;
 
 /// Interface for contract-related operations.
 pub trait ContractApi<R: Runtime> {

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -1,6 +1,6 @@
 //! This module provides a context-aware interface for interacting with contracts.
 
-use std::{mem, rc::Rc};
+use std::{mem, rc::Rc, fmt::Debug};
 
 pub use contract_transcode;
 use contract_transcode::ContractMessageTranscoder;
@@ -21,6 +21,12 @@ type Balance = u128;
 
 const ZERO_TRANSFER: Balance = 0;
 const DEFAULT_STORAGE_DEPOSIT_LIMIT: Option<Balance> = None;
+
+/// Convenient value for an empty sequence of call/instantiation arguments.
+///
+/// Without it, you would have to specify explicitly a compatible type, like:
+/// `session.call::<String>(.., &[], ..)`.
+pub const NO_ARGS: &[String] = &[];
 
 /// Session specific errors.
 #[derive(Error, Debug)]
@@ -89,8 +95,12 @@ pub type MessageResult<T> = Result<T, LangError>;
 /// ```rust, no_run
 /// # use std::rc::Rc;
 /// # use contract_transcode::ContractMessageTranscoder;
-/// # use drink::session::Session;
-/// # use drink::AccountId32;
+/// # use drink::{
+/// #   session::Session,
+/// #   AccountId32,
+/// #   session::NO_ARGS,
+/// #   runtime::MinimalRuntime
+/// # };
 /// #
 /// # fn get_transcoder() -> Rc<ContractMessageTranscoder> {
 /// #   Rc::new(ContractMessageTranscoder::load("").unwrap())
@@ -100,13 +110,11 @@ pub type MessageResult<T> = Result<T, LangError>;
 ///
 /// # fn main() -> Result<(), drink::session::SessionError> {
 ///
-/// use drink::runtime::MinimalRuntime;
-///
 /// Session::<MinimalRuntime>::new(Some(get_transcoder()))?
-///     .deploy_and(contract_bytes(), "new", &[], vec![], None)?
-///     .call_and("foo", &[], None)?
+///     .deploy_and(contract_bytes(), "new", NO_ARGS, vec![], None)?
+///     .call_and("foo", NO_ARGS, None)?
 ///     .with_actor(bob())
-///     .call_and("bar", &[], None)?;
+///     .call_and("bar", NO_ARGS, None)?;
 /// # Ok(()) }
 /// ```
 ///
@@ -114,9 +122,12 @@ pub type MessageResult<T> = Result<T, LangError>;
 /// ```rust, no_run
 /// # use std::rc::Rc;
 /// # use contract_transcode::ContractMessageTranscoder;
-/// # use drink::session::Session;
-/// # use drink::AccountId32;
-/// #
+/// # use drink::{
+/// #   session::Session,
+/// #   AccountId32,
+/// #   runtime::MinimalRuntime,
+/// #   session::NO_ARGS
+/// # };
 /// # fn get_transcoder() -> Rc<ContractMessageTranscoder> {
 /// #   Rc::new(ContractMessageTranscoder::load("").unwrap())
 /// # }
@@ -124,13 +135,12 @@ pub type MessageResult<T> = Result<T, LangError>;
 /// # fn bob() -> AccountId32 { AccountId32::new([0; 32]) }
 ///
 /// # fn main() -> Result<(), drink::session::SessionError> {
-/// use drink::runtime::MinimalRuntime;
 ///
 /// let mut session = Session::<MinimalRuntime>::new(Some(get_transcoder()))?;
-/// let _address = session.deploy(contract_bytes(), "new", &[], vec![], None)?;
-/// session.call("foo", &[], None)?;
+/// let _address = session.deploy(contract_bytes(), "new", NO_ARGS, vec![], None)?;
+/// session.call("foo", NO_ARGS, None)?;
 /// session.set_actor(bob());
-/// session.call("bar", &[], None)?;
+/// session.call("bar", NO_ARGS, None)?;
 /// # Ok(()) }
 /// ```
 pub struct Session<R: Runtime> {
@@ -207,11 +217,11 @@ impl<R: Runtime> Session<R> {
 
     /// Deploys a contract with a given constructor, arguments, salt and endowment. In case of
     /// success, returns `self`.
-    pub fn deploy_and(
+    pub fn deploy_and<S: AsRef<str> + Debug>(
         mut self,
         contract_bytes: Vec<u8>,
         constructor: &str,
-        args: &[String],
+        args: &[S],
         salt: Vec<u8>,
         endowment: Option<Balance>,
     ) -> Result<Self, SessionError> {
@@ -221,11 +231,11 @@ impl<R: Runtime> Session<R> {
 
     /// Deploys a contract with a given constructor, arguments, salt and endowment. In case of
     /// success, returns the address of the deployed contract.
-    pub fn deploy(
+    pub fn deploy<S: AsRef<str> + Debug>(
         &mut self,
         contract_bytes: Vec<u8>,
         constructor: &str,
-        args: &[String],
+        args: &[S],
         salt: Vec<u8>,
         endowment: Option<Balance>,
     ) -> Result<AccountIdFor<R>, SessionError> {
@@ -263,10 +273,10 @@ impl<R: Runtime> Session<R> {
     }
 
     /// Calls a contract with a given address. In case of a successful call, returns `self`.
-    pub fn call_and(
+    pub fn call_and<S: AsRef<str> + Debug>(
         mut self,
         message: &str,
-        args: &[String],
+        args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Self, SessionError> {
         self.call_internal(None, message, args, endowment)
@@ -274,11 +284,11 @@ impl<R: Runtime> Session<R> {
     }
 
     /// Calls the last deployed contract. In case of a successful call, returns `self`.
-    pub fn call_with_address_and(
+    pub fn call_with_address_and<S: AsRef<str> + Debug>(
         mut self,
         address: AccountIdFor<R>,
         message: &str,
-        args: &[String],
+        args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Self, SessionError> {
         self.call_internal(Some(address), message, args, endowment)
@@ -286,10 +296,10 @@ impl<R: Runtime> Session<R> {
     }
 
     /// Calls the last deployed contract. In case of a successful call, returns the decoded result.
-    pub fn call(
+    pub fn call<S: AsRef<str> + Debug>(
         &mut self,
         message: &str,
-        args: &[String],
+        args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Vec<u8>, SessionError> {
         self.call_internal(None, message, args, endowment)
@@ -297,21 +307,21 @@ impl<R: Runtime> Session<R> {
 
     /// Calls a contract with a given address. In case of a successful call, returns the decoded
     /// result.
-    pub fn call_with_address(
+    pub fn call_with_address<S: AsRef<str> + Debug>(
         &mut self,
         address: AccountIdFor<R>,
         message: &str,
-        args: &[String],
+        args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Vec<u8>, SessionError> {
         self.call_internal(Some(address), message, args, endowment)
     }
 
-    fn call_internal(
+    fn call_internal<S: AsRef<str> + Debug>(
         &mut self,
         address: Option<AccountIdFor<R>>,
         message: &str,
-        args: &[String],
+        args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Vec<u8>, SessionError> {
         let data = self

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -1,6 +1,6 @@
 //! This module provides a context-aware interface for interacting with contracts.
 
-use std::{mem, rc::Rc, fmt::Debug};
+use std::{fmt::Debug, mem, rc::Rc};
 
 pub use contract_transcode;
 use contract_transcode::ContractMessageTranscoder;

--- a/examples/cross-contract-call-tracing/lib.rs
+++ b/examples/cross-contract-call-tracing/lib.rs
@@ -156,9 +156,9 @@ mod tests {
             outer_address,
             "outer_call",
             &[
-                middle_address.to_string(),
-                inner_address.to_string(),
-                "7".to_string(),
+                &*middle_address.to_string(),
+                &*inner_address.to_string(),
+                "7",
             ],
             None,
         )?;

--- a/examples/cross-contract-call-tracing/lib.rs
+++ b/examples/cross-contract-call-tracing/lib.rs
@@ -71,7 +71,7 @@ mod tests {
         },
         session::{
             contract_transcode::{ContractMessageTranscoder, Value},
-            Session,
+            Session, NO_ARGS,
         },
         AccountId32,
     };
@@ -145,11 +145,11 @@ mod tests {
         let mut session = Session::<MinimalRuntime>::new(Some(transcoder()))?;
         session.override_debug_handle(DebugExt(Box::new(TestDebugger {})));
 
-        let outer_address = session.deploy(bytes(), "new", &[], vec![1], None)?;
+        let outer_address = session.deploy(bytes(), "new", NO_ARGS, vec![1], None)?;
         OUTER_ADDRESS.with(|a| *a.borrow_mut() = Some(outer_address.clone()));
-        let middle_address = session.deploy(bytes(), "new", &[], vec![2], None)?;
+        let middle_address = session.deploy(bytes(), "new", NO_ARGS, vec![2], None)?;
         MIDDLE_ADDRESS.with(|a| *a.borrow_mut() = Some(middle_address.clone()));
-        let inner_address = session.deploy(bytes(), "new", &[], vec![3], None)?;
+        let inner_address = session.deploy(bytes(), "new", NO_ARGS, vec![3], None)?;
         INNER_ADDRESS.with(|a| *a.borrow_mut() = Some(inner_address.clone()));
 
         let value = session.call_with_address(

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -36,7 +36,7 @@ mod tests {
 
     use drink::{
         runtime::MinimalRuntime,
-        session::{contract_transcode::ContractMessageTranscoder, Session},
+        session::{contract_transcode::ContractMessageTranscoder, Session, NO_ARGS},
     };
 
     fn transcoder() -> Option<Rc<ContractMessageTranscoder>> {
@@ -53,8 +53,8 @@ mod tests {
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
         let init_value: bool = Session::<MinimalRuntime>::new(transcoder())?
-            .deploy_and(bytes(), "new", &["true".to_string()], vec![], None)?
-            .call_and("get", &[], None)?
+            .deploy_and(bytes(), "new", &["true"], vec![], None)?
+            .call_and("get", NO_ARGS, None)?
             .last_call_return()
             .expect("Call was successful, so there should be a return")
             .expect("Call was successful");
@@ -67,11 +67,11 @@ mod tests {
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
         let init_value: bool = Session::<MinimalRuntime>::new(transcoder())?
-            .deploy_and(bytes(), "new", &["true".to_string()], vec![], None)?
-            .call_and("flip", &[], None)?
-            .call_and("flip", &[], None)?
-            .call_and("flip", &[], None)?
-            .call_and("get", &[], None)?
+            .deploy_and(bytes(), "new", &["true"], vec![], None)?
+            .call_and("flip", NO_ARGS, None)?
+            .call_and("flip", NO_ARGS, None)?
+            .call_and("flip", NO_ARGS, None)?
+            .call_and("get", NO_ARGS, None)?
             .last_call_return()
             .expect("Call was successful, so there should be a return")
             .expect("Call was successful");


### PR DESCRIPTION
Previously, calling/deploying with `Session` required that all arguments are converted to `String`. This was onerous to add `".to_string()"` for string literals. Instead we accept anything that is `AsRef<str> + Debug` (the `Debug` bound is required for encoding), which accepts now `String` and `&str`.

Since often messages don't have arguments, passing `&[]` requires specifying the explicit type. For that we define auxiliary constant `NO_ARGS` which is just empty `&[String]`.

---

Alternatively, we could be less restrictive and require only `Debug` or `Into<String> + Debug`. However, this might introduce problems / confusion for non-homogenic argument lists. Consider:
```rust
fn message1(account: AccountId) {..}
fn message2(account: AccountId, value: u128) {..}

let account: AccountId = ...;
let value: u128 = ...;

session.call("message1", &[account]) // works fine
session.call("message1", &[account.to_string()]) // works fine as well

session.call("message", &[account, value]) // this won't work - slice must contain values of the same type
session.call("message", &[account.to_string(), value.to_string()]) // we have to convert to string anyway
```
