### PR TITLE
Session: reorganize transcoder management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "contract-transcode",
  "frame-support",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "drink-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.3.0"
+version = "0.4.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -48,4 +48,4 @@ sp-runtime-interface = { version = "18.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.3.0", path = "drink" }
+drink = { version = "0.4.0", path = "drink" }

--- a/drink-cli/src/app_state/mod.rs
+++ b/drink-cli/src/app_state/mod.rs
@@ -82,7 +82,7 @@ pub struct AppState {
 impl AppState {
     pub fn new(cwd_override: Option<PathBuf>) -> Self {
         AppState {
-            session: Session::new(None).expect("Failed to create drinking session"),
+            session: Session::new().expect("Failed to create drinking session"),
             chain_info: Default::default(),
             ui_state: UiState::new(cwd_override),
             contracts: Default::default(),

--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -73,11 +73,14 @@ pub fn deploy(app_state: &mut AppState, constructor: String, args: Vec<String>, 
     };
     let transcoder = Rc::new(transcoder);
 
-    app_state.session.set_transcoder(Some(transcoder.clone()));
-    match app_state
-        .session
-        .deploy(contract_bytes, &constructor, args.as_slice(), salt, None)
-    {
+    match app_state.session.deploy(
+        contract_bytes,
+        &constructor,
+        args.as_slice(),
+        salt,
+        None,
+        &transcoder,
+    ) {
         Ok(address) => {
             app_state.contracts.add(Contract {
                 name: contract_name,
@@ -100,10 +103,6 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
         app_state.print_error("No deployed contract");
         return;
     };
-
-    app_state
-        .session
-        .set_transcoder(Some(contract.transcoder.clone()));
 
     let address = contract.address.clone();
     match app_state

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, mem, rc::Rc};
 
 pub use contract_transcode;
 use contract_transcode::ContractMessageTranscoder;
-use frame_support::{ weights::Weight};
+use frame_support::weights::Weight;
 use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult};
 use parity_scale_codec::Decode;
 
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub mod errors;
-use errors::{SessionError, MessageResult};
+use errors::{MessageResult, SessionError};
 
 type Balance = u128;
 

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -21,6 +21,8 @@ mod transcoding;
 
 use errors::{MessageResult, SessionError};
 
+use crate::session::transcoding::TranscoderRegistry;
+
 type Balance = u128;
 
 const ZERO_TRANSFER: Balance = 0;
@@ -54,10 +56,10 @@ pub const NO_ARGS: &[String] = &[];
 /// # fn contract_bytes() -> Vec<u8> { vec![] }
 /// # fn bob() -> AccountId32 { AccountId32::new([0; 32]) }
 ///
-/// # fn main() -> Result<(), drink::session::SessionError> {
+/// # fn main() -> Result<(), drink::session::errors::SessionError> {
 ///
-/// Session::<MinimalRuntime>::new(Some(get_transcoder()))?
-///     .deploy_and(contract_bytes(), "new", NO_ARGS, vec![], None)?
+/// Session::<MinimalRuntime>::new()?
+///     .deploy_and(contract_bytes(), "new", NO_ARGS, vec![], None, &get_transcoder())?
 ///     .call_and("foo", NO_ARGS, None)?
 ///     .with_actor(bob())
 ///     .call_and("bar", NO_ARGS, None)?;
@@ -80,10 +82,10 @@ pub const NO_ARGS: &[String] = &[];
 /// # fn contract_bytes() -> Vec<u8> { vec![] }
 /// # fn bob() -> AccountId32 { AccountId32::new([0; 32]) }
 ///
-/// # fn main() -> Result<(), drink::session::SessionError> {
+/// # fn main() -> Result<(), drink::session::errors::SessionError> {
 ///
-/// let mut session = Session::<MinimalRuntime>::new(Some(get_transcoder()))?;
-/// let _address = session.deploy(contract_bytes(), "new", NO_ARGS, vec![], None)?;
+/// let mut session = Session::<MinimalRuntime>::new()?;
+/// let _address = session.deploy(contract_bytes(), "new", NO_ARGS, vec![], None, &get_transcoder())?;
 /// session.call("foo", NO_ARGS, None)?;
 /// session.set_actor(bob());
 /// session.call("bar", NO_ARGS, None)?;
@@ -95,7 +97,7 @@ pub struct Session<R: Runtime> {
     actor: AccountIdFor<R>,
     gas_limit: Weight,
 
-    transcoder: Option<Rc<ContractMessageTranscoder>>,
+    transcoders: TranscoderRegistry<AccountIdFor<R>>,
 
     deploy_results: Vec<ContractInstantiateResult<AccountIdFor<R>, Balance, EventRecordOf<R>>>,
     deploy_returns: Vec<AccountIdFor<R>>,
@@ -104,13 +106,13 @@ pub struct Session<R: Runtime> {
 }
 
 impl<R: Runtime> Session<R> {
-    /// Creates a new `Session` with optional reference to a transcoder.
-    pub fn new(transcoder: Option<Rc<ContractMessageTranscoder>>) -> Result<Self, SessionError> {
+    /// Creates a new `Session`.
+    pub fn new() -> Result<Self, SessionError> {
         Ok(Self {
             sandbox: Sandbox::new().map_err(SessionError::Drink)?,
             actor: R::default_actor(),
             gas_limit: DEFAULT_GAS_LIMIT,
-            transcoder,
+            transcoders: TranscoderRegistry::new(),
             deploy_results: vec![],
             deploy_returns: vec![],
             call_results: vec![],
@@ -138,17 +140,23 @@ impl<R: Runtime> Session<R> {
         mem::replace(&mut self.gas_limit, gas_limit)
     }
 
-    /// Sets a new transcoder and returns updated `self`.
-    pub fn with_transcoder(self, transcoder: Option<Rc<ContractMessageTranscoder>>) -> Self {
-        Self { transcoder, ..self }
+    /// Register a transcoder for a particular contract and returns updated `self`.
+    pub fn with_transcoder(
+        mut self,
+        contract_address: AccountIdFor<R>,
+        transcoder: &Rc<ContractMessageTranscoder>,
+    ) -> Self {
+        self.set_transcoder(contract_address, transcoder);
+        self
     }
 
-    /// Sets a new transcoder and returns the old one.
+    /// Registers a transcoder for a particular contract.
     pub fn set_transcoder(
         &mut self,
-        transcoder: Option<Rc<ContractMessageTranscoder>>,
-    ) -> Option<Rc<ContractMessageTranscoder>> {
-        mem::replace(&mut self.transcoder, transcoder)
+        contract_address: AccountIdFor<R>,
+        transcoder: &Rc<ContractMessageTranscoder>,
+    ) {
+        self.transcoders.register(contract_address, transcoder);
     }
 
     /// Returns a reference for basic chain API.
@@ -170,9 +178,17 @@ impl<R: Runtime> Session<R> {
         args: &[S],
         salt: Vec<u8>,
         endowment: Option<Balance>,
+        transcoder: &Rc<ContractMessageTranscoder>,
     ) -> Result<Self, SessionError> {
-        self.deploy(contract_bytes, constructor, args, salt, endowment)
-            .map(|_| self)
+        self.deploy(
+            contract_bytes,
+            constructor,
+            args,
+            salt,
+            endowment,
+            transcoder,
+        )
+        .map(|_| self)
     }
 
     /// Deploys a contract with a given constructor, arguments, salt and endowment. In case of
@@ -184,11 +200,9 @@ impl<R: Runtime> Session<R> {
         args: &[S],
         salt: Vec<u8>,
         endowment: Option<Balance>,
+        transcoder: &Rc<ContractMessageTranscoder>,
     ) -> Result<AccountIdFor<R>, SessionError> {
-        let data = self
-            .transcoder
-            .as_ref()
-            .ok_or(SessionError::NoTranscoder)?
+        let data = transcoder
             .encode(constructor, args)
             .map_err(|err| SessionError::Encoding(err.to_string()))?;
 
@@ -209,6 +223,9 @@ impl<R: Runtime> Session<R> {
             Ok(exec_result) => {
                 let address = exec_result.account_id.clone();
                 self.deploy_returns.push(address.clone());
+
+                self.transcoders.register(address.clone(), transcoder);
+
                 Ok(address)
             }
             Err(err) => Err(SessionError::DeploymentFailed(*err)),
@@ -288,13 +305,6 @@ impl<R: Runtime> Session<R> {
         args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Vec<u8>, SessionError> {
-        let data = self
-            .transcoder
-            .as_ref()
-            .ok_or(SessionError::NoTranscoder)?
-            .encode(message, args)
-            .map_err(|err| SessionError::Encoding(err.to_string()))?;
-
         let address = match address {
             Some(address) => address,
             None => self
@@ -303,6 +313,14 @@ impl<R: Runtime> Session<R> {
                 .ok_or(SessionError::NoContract)?
                 .clone(),
         };
+
+        let data = self
+            .transcoders
+            .get(&address)
+            .as_ref()
+            .ok_or(SessionError::NoTranscoder)?
+            .encode(message, args)
+            .map_err(|err| SessionError::Encoding(err.to_string()))?;
 
         let result = self.sandbox.call_contract(
             address,

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -17,6 +17,8 @@ use crate::{
 };
 
 pub mod errors;
+mod transcoding;
+
 use errors::{MessageResult, SessionError};
 
 type Balance = u128;

--- a/drink/src/session/errors.rs
+++ b/drink/src/session/errors.rs
@@ -1,7 +1,7 @@
 //! Module exposing errors and result types for the session API.
 
-use thiserror::Error;
 use frame_support::sp_runtime::DispatchError;
+use thiserror::Error;
 
 /// Session specific errors.
 #[derive(Error, Debug)]
@@ -45,15 +45,15 @@ pub enum SessionError {
 #[non_exhaustive]
 #[repr(u32)]
 #[derive(
-Debug,
-Copy,
-Clone,
-PartialEq,
-Eq,
-parity_scale_codec::Encode,
-parity_scale_codec::Decode,
-scale_info::TypeInfo,
-Error,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    parity_scale_codec::Encode,
+    parity_scale_codec::Decode,
+    scale_info::TypeInfo,
+    Error,
 )]
 pub enum LangError {
     /// Failed to read execution input for the dispatchable.

--- a/drink/src/session/errors.rs
+++ b/drink/src/session/errors.rs
@@ -1,0 +1,65 @@
+//! Module exposing errors and result types for the session API.
+
+use thiserror::Error;
+use frame_support::sp_runtime::DispatchError;
+
+/// Session specific errors.
+#[derive(Error, Debug)]
+pub enum SessionError {
+    /// Encoding data failed.
+    #[error("Encoding call data failed: {0}")]
+    Encoding(String),
+    /// Decoding data failed.
+    #[error("Decoding call data failed: {0}")]
+    Decoding(String),
+    /// Crate-specific error.
+    #[error("{0:?}")]
+    Drink(#[from] crate::Error),
+    /// Deployment has been reverted by the contract.
+    #[error("Contract deployment has been reverted")]
+    DeploymentReverted,
+    /// Deployment failed (aborted by the pallet).
+    #[error("Contract deployment failed before execution: {0:?}")]
+    DeploymentFailed(DispatchError),
+    /// Code upload failed (aborted by the pallet).
+    #[error("Code upload failed: {0:?}")]
+    UploadFailed(DispatchError),
+    /// Call has been reverted by the contract.
+    #[error("Contract call has been reverted")]
+    CallReverted,
+    /// Contract call failed (aborted by the pallet).
+    #[error("Contract call failed before execution: {0:?}")]
+    CallFailed(DispatchError),
+    /// There is no deployed contract to call.
+    #[error("No deployed contract")]
+    NoContract,
+    /// There is no transcoder to encode/decode contract messages.
+    #[error("Missing transcoder")]
+    NoTranscoder,
+}
+
+/// Every contract message wraps its return value in `Result<T, LangResult>`. This is the error
+/// type.
+///
+/// Copied from ink primitives.
+#[non_exhaustive]
+#[repr(u32)]
+#[derive(
+Debug,
+Copy,
+Clone,
+PartialEq,
+Eq,
+parity_scale_codec::Encode,
+parity_scale_codec::Decode,
+scale_info::TypeInfo,
+Error,
+)]
+pub enum LangError {
+    /// Failed to read execution input for the dispatchable.
+    #[error("Failed to read execution input for the dispatchable.")]
+    CouldNotReadInput = 1u32,
+}
+
+/// The `Result` type for ink! messages.
+pub type MessageResult<T> = Result<T, LangError>;

--- a/drink/src/session/errors.rs
+++ b/drink/src/session/errors.rs
@@ -33,7 +33,7 @@ pub enum SessionError {
     /// There is no deployed contract to call.
     #[error("No deployed contract")]
     NoContract,
-    /// There is no transcoder to encode/decode contract messages.
+    /// There is no registered transcoder to encode/decode messages for the called contract.
     #[error("Missing transcoder")]
     NoTranscoder,
 }

--- a/drink/src/session/transcoding.rs
+++ b/drink/src/session/transcoding.rs
@@ -1,15 +1,20 @@
-use std::{collections::HashMap, hash::Hash, rc::Rc};
+use std::{collections::BTreeMap, rc::Rc};
 
 use contract_transcode::ContractMessageTranscoder;
 
-#[derive(Default)]
-pub struct TranscoderRegistry<Contract: Eq + Hash> {
-    transcoders: HashMap<Contract, Rc<ContractMessageTranscoder>>,
+pub struct TranscoderRegistry<Contract: Ord> {
+    transcoders: BTreeMap<Contract, Rc<ContractMessageTranscoder>>,
 }
 
-impl<Contract: Eq + Hash> TranscoderRegistry<Contract> {
-    pub fn register(&mut self, contract: Contract, transcoder: Rc<ContractMessageTranscoder>) {
-        self.transcoders.insert(contract, Rc::clone(&transcoder));
+impl<Contract: Ord> TranscoderRegistry<Contract> {
+    pub fn new() -> Self {
+        Self {
+            transcoders: BTreeMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, contract: Contract, transcoder: &Rc<ContractMessageTranscoder>) {
+        self.transcoders.insert(contract, Rc::clone(transcoder));
     }
 
     pub fn get(&self, contract: &Contract) -> Option<Rc<ContractMessageTranscoder>> {

--- a/drink/src/session/transcoding.rs
+++ b/drink/src/session/transcoding.rs
@@ -1,0 +1,18 @@
+use std::{collections::HashMap, hash::Hash, rc::Rc};
+
+use contract_transcode::ContractMessageTranscoder;
+
+#[derive(Default)]
+pub struct TranscoderRegistry<Contract: Eq + Hash> {
+    transcoders: HashMap<Contract, Rc<ContractMessageTranscoder>>,
+}
+
+impl<Contract: Eq + Hash> TranscoderRegistry<Contract> {
+    pub fn register(&mut self, contract: Contract, transcoder: Rc<ContractMessageTranscoder>) {
+        self.transcoders.insert(contract, Rc::clone(&transcoder));
+    }
+
+    pub fn get(&self, contract: &Contract) -> Option<Rc<ContractMessageTranscoder>> {
+        self.transcoders.get(contract).map(Rc::clone)
+    }
+}

--- a/examples/cross-contract-call-tracing/lib.rs
+++ b/examples/cross-contract-call-tracing/lib.rs
@@ -142,14 +142,17 @@ mod tests {
 
     #[test]
     fn test() -> Result<(), Box<dyn Error>> {
-        let mut session = Session::<MinimalRuntime>::new(Some(transcoder()))?;
+        let mut session = Session::<MinimalRuntime>::new()?;
         session.override_debug_handle(DebugExt(Box::new(TestDebugger {})));
 
-        let outer_address = session.deploy(bytes(), "new", NO_ARGS, vec![1], None)?;
+        let outer_address =
+            session.deploy(bytes(), "new", NO_ARGS, vec![1], None, &transcoder())?;
         OUTER_ADDRESS.with(|a| *a.borrow_mut() = Some(outer_address.clone()));
-        let middle_address = session.deploy(bytes(), "new", NO_ARGS, vec![2], None)?;
+        let middle_address =
+            session.deploy(bytes(), "new", NO_ARGS, vec![2], None, &transcoder())?;
         MIDDLE_ADDRESS.with(|a| *a.borrow_mut() = Some(middle_address.clone()));
-        let inner_address = session.deploy(bytes(), "new", NO_ARGS, vec![3], None)?;
+        let inner_address =
+            session.deploy(bytes(), "new", NO_ARGS, vec![3], None, &transcoder())?;
         INNER_ADDRESS.with(|a| *a.borrow_mut() = Some(inner_address.clone()));
 
         let value = session.call_with_address(

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -39,11 +39,11 @@ mod tests {
         session::{contract_transcode::ContractMessageTranscoder, Session, NO_ARGS},
     };
 
-    fn transcoder() -> Option<Rc<ContractMessageTranscoder>> {
-        Some(Rc::new(
+    fn transcoder() -> Rc<ContractMessageTranscoder> {
+        Rc::new(
             ContractMessageTranscoder::load(PathBuf::from("./target/ink/flipper.json"))
                 .expect("Failed to create transcoder"),
-        ))
+        )
     }
 
     fn bytes() -> Vec<u8> {
@@ -52,8 +52,8 @@ mod tests {
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
-        let init_value: bool = Session::<MinimalRuntime>::new(transcoder())?
-            .deploy_and(bytes(), "new", &["true"], vec![], None)?
+        let init_value: bool = Session::<MinimalRuntime>::new()?
+            .deploy_and(bytes(), "new", &["true"], vec![], None, &transcoder())?
             .call_and("get", NO_ARGS, None)?
             .last_call_return()
             .expect("Call was successful, so there should be a return")
@@ -66,8 +66,8 @@ mod tests {
 
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
-        let init_value: bool = Session::<MinimalRuntime>::new(transcoder())?
-            .deploy_and(bytes(), "new", &["true"], vec![], None)?
+        let init_value: bool = Session::<MinimalRuntime>::new()?
+            .deploy_and(bytes(), "new", &["true"], vec![], None, &transcoder())?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?


### PR DESCRIPTION
Instead of keeping only a single 'active' transcoder, `Session` object now keeps a transcoder registry, i.e. a mapping from contract address to a corresponding transcoder. The new API:
 - the `Session` constructor takes no arguments
 - while deploying a contract you must pass a shared reference to a corresponding transcoder; in case of success, the new contract address will be internally connected with the transcoder
 - while calling a contract address, the corresponding transcoder will be looked up in the registry
 - for already deployed contracts, you can register their transcoders with `set_transcoder` or `with_transcoder` methods

Also, a minor refactor has been done: error and result types related to session have been moved to a submodule