### PR TITLE
Enable loading contract bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c18e3c8d036bcb58c26a5c96cc97e9667c66c31c531de048cf6bc55fa4f83a7"
+checksum = "39a88f62795e84270742796456086ddeebfa4cbd4e56f02777f792192d666725"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24c67f09efbe97322841746b22cab3ffb5d26c2732347b43ad4c994fc5fbe5d"
+checksum = "91279ca8e8a05dec90febb12a9529b310018c623adaebe691d9b2e8cc115a182"
 dependencies = [
  "anyhow",
  "base58",
@@ -1017,6 +1017,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 name = "drink"
 version = "0.5.1"
 dependencies = [
+ "contract-metadata",
  "contract-transcode",
  "frame-metadata",
  "frame-support",
@@ -1028,6 +1029,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "scale-info",
+ "serde_json",
  "sp-externalities",
  "sp-io",
  "sp-runtime-interface",
@@ -3239,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ version = "0.5.1"
 anyhow = { version = "1.0.71" }
 clap = { version = "4.3.4" }
 contract-build = { version = "3.0.1" }
-contract-transcode = { version = "3.0.1" }
+contract-metadata = { version = "3.2.0" }
+contract-transcode = { version = "3.2.0" }
 crossterm = { version = "0.26.0" }
 parity-scale-codec = { version = "3.4" }
 parity-scale-codec-derive = { version = "3.4" }
@@ -34,6 +35,8 @@ ratatui = { version = "0.21.0" }
 scale-info = { version = "2.5.0" }
 thiserror = { version = "1.0.40" }
 wat = { version = "1.0.71" }
+
+serde_json = { version = "1.0.106" }
 
 # Substrate dependencies
 

--- a/drink/Cargo.toml
+++ b/drink/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 description = "Minimal sufficient architecture that allows for a fully functional ink! contract development"
 
 [dependencies]
-contract-metadata = { workspace = true }
+contract-metadata = { workspace = true, optional = true}
 contract-transcode = { workspace = true, optional = true }
 frame-metadata = { workspace = true }
 frame-support = { workspace = true }
@@ -25,7 +25,7 @@ sp-externalities = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime-interface = { workspace = true }
 
-serde_json = { workspace = true }
+serde_json = { workspace = true, optional = true }
 scale-info = { workspace = true }
 thiserror = { workspace = true }
 wat = { workspace = true }
@@ -36,5 +36,5 @@ default = [
     "std",
     "session"
 ]
-session = ["contract-transcode"]
+session = ["contract-metadata", "contract-transcode", "serde_json"]
 std = []

--- a/drink/Cargo.toml
+++ b/drink/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 description = "Minimal sufficient architecture that allows for a fully functional ink! contract development"
 
 [dependencies]
+contract-metadata = { workspace = true }
 contract-transcode = { workspace = true, optional = true }
 frame-metadata = { workspace = true }
 frame-support = { workspace = true }
@@ -24,6 +25,7 @@ sp-externalities = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime-interface = { workspace = true }
 
+serde_json = { workspace = true }
 scale-info = { workspace = true }
 thiserror = { workspace = true }
 wat = { workspace = true }

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 mod bundle;
-pub use bundle::ContractBundle;
+pub use bundle::ContractFile;
 pub mod error;
 mod transcoding;
 
@@ -97,8 +97,8 @@ pub const NO_ARGS: &[String] = &[];
 /// You can also work with `.contract` bundles like so:
 /// ```rust, no_run
 /// # use drink::{
-/// #   local_bundle,
-/// #   session::{ContractBundle, Session},
+/// #   local_contract_file,
+/// #   session::{ContractFile, Session},
 /// #   session::NO_ARGS,
 /// #   runtime::MinimalRuntime
 /// # };
@@ -106,12 +106,12 @@ pub const NO_ARGS: &[String] = &[];
 /// # fn main() -> Result<(), drink::session::error::SessionError> {
 /// // Simplest way, loading a bundle from the project's directory:
 /// Session::<MinimalRuntime>::new()?
-///     .deploy_bundle_and(local_bundle!(), "new", NO_ARGS, vec![], None); /* ... */
+///     .deploy_contract_and(local_contract_file!(), "new", NO_ARGS, vec![], None); /* ... */
 ///
 /// // Or choosing the file explicitly:
-/// let contract = ContractBundle::load("path/to/your.contract")?;
+/// let contract = ContractFile::load("path/to/your.contract")?;
 /// Session::<MinimalRuntime>::new()?
-///     .deploy_bundle_and(contract, "new", NO_ARGS, vec![], None); /* ... */
+///     .deploy_contract_and(contract, "new", NO_ARGS, vec![], None); /* ... */
 ///  # Ok(()) }
 /// ```
 pub struct Session<R: Runtime> {
@@ -265,37 +265,37 @@ impl<R: Runtime> Session<R> {
 
     /// Similar to `deploy` but takes the contract bundle as a first argument.
     ///
-    /// You can get it with `ContractBundle::load("some/path/your.contract")` or `local_bundle!()`
-    pub fn deploy_bundle<S: AsRef<str> + Debug>(
+    /// You can get it with `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn deploy_contract<S: AsRef<str> + Debug>(
         &mut self,
-        contract_bundle: ContractBundle,
+        contract_file: ContractFile,
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
         endowment: Option<Balance>,
     ) -> Result<AccountIdFor<R>, SessionError> {
         self.deploy(
-            contract_bundle.bytes,
+            contract_file.wasm,
             constructor,
             args,
             salt,
             endowment,
-            &contract_bundle.transcoder,
+            &contract_file.transcoder,
         )
     }
 
     /// Similar to `deploy_and` but takes the contract bundle as a first argument.
     ///
-    /// You can get it with `ContractBundle::load("some/path/your.contract")` or `local_bundle!()`
-    pub fn deploy_bundle_and<S: AsRef<str> + Debug>(
+    /// You can get it with `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn deploy_contract_and<S: AsRef<str> + Debug>(
         mut self,
-        contract_bundle: ContractBundle,
+        contract_file: ContractFile,
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
         endowment: Option<Balance>,
     ) -> Result<Self, SessionError> {
-        self.deploy_bundle(contract_bundle, constructor, args, salt, endowment)
+        self.deploy_contract(contract_file, constructor, args, salt, endowment)
             .map(|_| self)
     }
 
@@ -319,19 +319,19 @@ impl<R: Runtime> Session<R> {
 
     /// Similar to `upload_and` but takes the contract bundle as the first argument.
     ///
-    /// You can obtain it using `ContractBundle::load("some/path/your.contract")` or `local_bundle!()`
-    pub fn upload_bundle_and(self, contract_bundle: ContractBundle) -> Result<Self, SessionError> {
-        self.upload_and(contract_bundle.bytes)
+    /// You can obtain it using `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn upload_contract_and(self, contract_file: ContractFile) -> Result<Self, SessionError> {
+        self.upload_and(contract_file.wasm)
     }
 
     /// Similar to `upload` but takes the contract bundle as the first argument.
     ///
-    /// You can obtain it using `ContractBundle::load("some/path/your.contract")` or `local_bundle!()`
-    pub fn upload_bundle(
+    /// You can obtain it using `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn upload_contract(
         &mut self,
-        contract_bundle: ContractBundle,
+        contract_file: ContractFile,
     ) -> Result<HashFor<R>, SessionError> {
-        self.upload(contract_bundle.bytes)
+        self.upload(contract_file.wasm)
     }
 
     /// Calls a contract with a given address. In case of a successful call, returns `self`.

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 mod bundle;
-pub use bundle::ContractFile;
+pub use bundle::ContractBundle;
 pub mod error;
 mod transcoding;
 
@@ -98,7 +98,7 @@ pub const NO_ARGS: &[String] = &[];
 /// ```rust, no_run
 /// # use drink::{
 /// #   local_contract_file,
-/// #   session::{ContractFile, Session},
+/// #   session::{ContractBundle, Session},
 /// #   session::NO_ARGS,
 /// #   runtime::MinimalRuntime
 /// # };
@@ -106,12 +106,12 @@ pub const NO_ARGS: &[String] = &[];
 /// # fn main() -> Result<(), drink::session::error::SessionError> {
 /// // Simplest way, loading a bundle from the project's directory:
 /// Session::<MinimalRuntime>::new()?
-///     .deploy_contract_and(local_contract_file!(), "new", NO_ARGS, vec![], None); /* ... */
+///     .deploy_bundle_and(local_contract_file!(), "new", NO_ARGS, vec![], None); /* ... */
 ///
 /// // Or choosing the file explicitly:
-/// let contract = ContractFile::load("path/to/your.contract")?;
+/// let contract = ContractBundle::load("path/to/your.contract")?;
 /// Session::<MinimalRuntime>::new()?
-///     .deploy_contract_and(contract, "new", NO_ARGS, vec![], None); /* ... */
+///     .deploy_bundle_and(contract, "new", NO_ARGS, vec![], None); /* ... */
 ///  # Ok(()) }
 /// ```
 pub struct Session<R: Runtime> {
@@ -263,12 +263,12 @@ impl<R: Runtime> Session<R> {
         ret
     }
 
-    /// Similar to `deploy` but takes the contract bundle as a first argument.
+    /// Similar to `deploy` but takes the parsed contract file (`ContractBundle`) as a first argument.
     ///
-    /// You can get it with `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
-    pub fn deploy_contract<S: AsRef<str> + Debug>(
+    /// You can get it with `ContractBundle::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn deploy_bundle<S: AsRef<str> + Debug>(
         &mut self,
-        contract_file: ContractFile,
+        contract_file: ContractBundle,
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
@@ -284,18 +284,18 @@ impl<R: Runtime> Session<R> {
         )
     }
 
-    /// Similar to `deploy_and` but takes the contract bundle as a first argument.
+    /// Similar to `deploy_and` but takes the parsed contract file (`ContractBundle`) as a first argument.
     ///
-    /// You can get it with `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
-    pub fn deploy_contract_and<S: AsRef<str> + Debug>(
+    /// You can get it with `ContractBundle::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn deploy_bundle_and<S: AsRef<str> + Debug>(
         mut self,
-        contract_file: ContractFile,
+        contract_file: ContractBundle,
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
         endowment: Option<Balance>,
     ) -> Result<Self, SessionError> {
-        self.deploy_contract(contract_file, constructor, args, salt, endowment)
+        self.deploy_bundle(contract_file, constructor, args, salt, endowment)
             .map(|_| self)
     }
 
@@ -319,17 +319,17 @@ impl<R: Runtime> Session<R> {
 
     /// Similar to `upload_and` but takes the contract bundle as the first argument.
     ///
-    /// You can obtain it using `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
-    pub fn upload_contract_and(self, contract_file: ContractFile) -> Result<Self, SessionError> {
+    /// You can obtain it using `ContractBundle::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn upload_bundle_and(self, contract_file: ContractBundle) -> Result<Self, SessionError> {
         self.upload_and(contract_file.wasm)
     }
 
     /// Similar to `upload` but takes the contract bundle as the first argument.
     ///
-    /// You can obtain it using `ContractFile::load("some/path/your.contract")` or `local_contract_file!()`
-    pub fn upload_contract(
+    /// You can obtain it using `ContractBundle::load("some/path/your.contract")` or `local_contract_file!()`
+    pub fn upload_bundle(
         &mut self,
-        contract_file: ContractFile,
+        contract_file: ContractBundle,
     ) -> Result<HashFor<R>, SessionError> {
         self.upload(contract_file.wasm)
     }

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -1,8 +1,7 @@
 //! This module provides a context-aware interface for interacting with contracts.
 
-use std::{fmt::Debug, mem, path::PathBuf, rc::Rc};
+use std::{fmt::Debug, mem, rc::Rc};
 
-use contract_metadata::ContractMetadata;
 pub use contract_transcode;
 use contract_transcode::ContractMessageTranscoder;
 use frame_support::weights::Weight;
@@ -17,6 +16,8 @@ use crate::{
     EventRecordOf, Sandbox, DEFAULT_GAS_LIMIT,
 };
 
+mod bundle;
+pub use bundle::ContractBundle;
 pub mod error;
 mod transcoding;
 
@@ -469,72 +470,4 @@ impl<R: Runtime> Session<R> {
     pub fn override_debug_handle(&mut self, d: TracingExt) {
         self.sandbox.override_debug_handle(d);
     }
-}
-
-/// A struct representing the result of parsing a `.contract` bundle file.
-///
-/// It can be used with the following methods of the `Session` struct:
-/// - `deploy_bundle`
-/// - `deploy_bundle_and`
-/// - `upload_bundle`
-/// - `upload_bundle_and`
-pub struct ContractBundle {
-    /// WASM blob of the contract
-    bytes: Vec<u8>,
-    /// Transcoder derived from the ABI/metadata
-    transcoder: Rc<ContractMessageTranscoder>,
-}
-
-impl ContractBundle {
-    /// Load and parse the information in a `.contract` bundle under `path`, producing a `ContractBundle` struct.
-    pub fn load<P>(path: P) -> Result<Self, SessionError>
-    where
-        P: AsRef<std::path::Path>,
-    {
-        let metadata: ContractMetadata = ContractMetadata::load(&path).map_err(|e| {
-            SessionError::BundleLoadFailed(format!("Failed to load the contract file:\n{e:?}"))
-        })?;
-
-        let ink_metadata = serde_json::from_value(serde_json::Value::Object(metadata.abi))
-            .map_err(|e| {
-                SessionError::BundleLoadFailed(format!(
-                    "Failed to parse metadata from the contract file:\n{e:?}"
-                ))
-            })?;
-
-        let bytes = metadata
-            .source
-            .wasm
-            .ok_or(SessionError::BundleLoadFailed(
-                "Failed to get the WASM blob from the contract file".to_string(),
-            ))?
-            .0;
-
-        let transcoder = Rc::new(ContractMessageTranscoder::new(ink_metadata));
-
-        Ok(Self { bytes, transcoder })
-    }
-
-    /// Load the `.contract` bundle (`bundle_file`) located in the `project_dir`` working directory.
-    ///
-    /// This is meant to be used predominantly by the `local_bundle!` macro.
-    pub fn local(project_dir: &str, bundle_file: String) -> Self {
-        let mut path = PathBuf::from(project_dir);
-        path.push("target");
-        path.push("ink");
-        path.push(bundle_file);
-        Self::load(path).expect("Loading the local bundle failed")
-    }
-}
-
-/// A convenience macro that allows you to load a bundle found in the target directory
-/// of the current project.
-#[macro_export]
-macro_rules! local_bundle {
-    () => {
-        drink::session::ContractBundle::local(
-            env!("CARGO_MANIFEST_DIR"),
-            env!("CARGO_CRATE_NAME").to_owned() + ".contract",
-        )
-    };
 }

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -96,19 +96,22 @@ pub const NO_ARGS: &[String] = &[];
 /// You can also work with `.contract` bundles like so:
 /// ```rust, no_run
 /// # use drink::{
-/// #   session::{ContractBundle, load_bundle, Session},
+/// #   local_bundle,
+/// #   session::{ContractBundle, Session},
 /// #   session::NO_ARGS,
 /// #   runtime::MinimalRuntime
 /// # };
 ///
+/// # fn main() -> Result<(), drink::session::error::SessionError> {
 /// // Simplest way, loading a bundle from the project's directory:
 /// Session::<MinimalRuntime>::new()?
-///     .deploy_bundle_and(load_bundle!(), "new", NO_ARGS, vec![], None, &get_transcoder())?
+///     .deploy_bundle_and(local_bundle!(), "new", NO_ARGS, vec![], None); /* ... */
 ///
 /// // Or choosing the file explicitly:
-/// let contract = ContractBundle::load("path/to/your.contract");
+/// let contract = ContractBundle::load("path/to/your.contract")?;
 /// Session::<MinimalRuntime>::new()?
-///     .deploy_bundle_and(contract, "new", NO_ARGS, vec![], None, &get_transcoder())?
+///     .deploy_bundle_and(contract, "new", NO_ARGS, vec![], None); /* ... */
+///  # Ok(()) }
 /// ```
 pub struct Session<R: Runtime> {
     sandbox: Sandbox<R>,

--- a/drink/src/session/bundle.rs
+++ b/drink/src/session/bundle.rs
@@ -14,15 +14,15 @@ use super::error::SessionError;
 /// - `deploy_bundle_and`
 /// - `upload_bundle`
 /// - `upload_bundle_and`
-pub struct ContractFile {
+pub struct ContractBundle {
     /// WASM blob of the contract
     pub wasm: Vec<u8>,
     /// Transcoder derived from the ABI/metadata
     pub transcoder: Rc<ContractMessageTranscoder>,
 }
 
-impl ContractFile {
-    /// Load and parse the information in a `.contract` bundle under `path`, producing a `ContractFile` struct.
+impl ContractBundle {
+    /// Load and parse the information in a `.contract` bundle under `path`, producing a `ContractBundle` struct.
     pub fn load<P>(path: P) -> Result<Self, SessionError>
     where
         P: AsRef<std::path::Path>,
@@ -68,7 +68,7 @@ impl ContractFile {
 #[macro_export]
 macro_rules! local_contract_file {
     () => {
-        drink::session::ContractFile::local(
+        drink::session::ContractBundle::local(
             env!("CARGO_MANIFEST_DIR"),
             env!("CARGO_CRATE_NAME").to_owned() + ".contract",
         )

--- a/drink/src/session/bundle.rs
+++ b/drink/src/session/bundle.rs
@@ -1,0 +1,76 @@
+//! This module provides simple utilities for loading and parsing `.contract` files in context of `drink` tests.
+
+use std::{path::PathBuf, rc::Rc};
+
+use contract_metadata::ContractMetadata;
+use contract_transcode::ContractMessageTranscoder;
+
+use super::error::SessionError;
+
+/// A struct representing the result of parsing a `.contract` bundle file.
+///
+/// It can be used with the following methods of the `Session` struct:
+/// - `deploy_bundle`
+/// - `deploy_bundle_and`
+/// - `upload_bundle`
+/// - `upload_bundle_and`
+pub struct ContractBundle {
+    /// WASM blob of the contract
+    pub bytes: Vec<u8>,
+    /// Transcoder derived from the ABI/metadata
+    pub transcoder: Rc<ContractMessageTranscoder>,
+}
+
+impl ContractBundle {
+    /// Load and parse the information in a `.contract` bundle under `path`, producing a `ContractBundle` struct.
+    pub fn load<P>(path: P) -> Result<Self, SessionError>
+    where
+        P: AsRef<std::path::Path>,
+    {
+        let metadata: ContractMetadata = ContractMetadata::load(&path).map_err(|e| {
+            SessionError::BundleLoadFailed(format!("Failed to load the contract file:\n{e:?}"))
+        })?;
+
+        let ink_metadata = serde_json::from_value(serde_json::Value::Object(metadata.abi))
+            .map_err(|e| {
+                SessionError::BundleLoadFailed(format!(
+                    "Failed to parse metadata from the contract file:\n{e:?}"
+                ))
+            })?;
+
+        let transcoder = Rc::new(ContractMessageTranscoder::new(ink_metadata));
+
+        let bytes = metadata
+            .source
+            .wasm
+            .ok_or(SessionError::BundleLoadFailed(
+                "Failed to get the WASM blob from the contract file".to_string(),
+            ))?
+            .0;
+            
+        Ok(Self { bytes, transcoder })
+    }
+
+    /// Load the `.contract` bundle (`bundle_file`) located in the `project_dir`` working directory.
+    ///
+    /// This is meant to be used predominantly by the `local_bundle!` macro.
+    pub fn local(project_dir: &str, bundle_file: String) -> Self {
+        let mut path = PathBuf::from(project_dir);
+        path.push("target");
+        path.push("ink");
+        path.push(bundle_file);
+        Self::load(path).expect("Loading the local bundle failed")
+    }
+}
+
+/// A convenience macro that allows you to load a bundle found in the target directory
+/// of the current project.
+#[macro_export]
+macro_rules! local_bundle {
+    () => {
+        drink::session::ContractBundle::local(
+            env!("CARGO_MANIFEST_DIR"),
+            env!("CARGO_CRATE_NAME").to_owned() + ".contract",
+        )
+    };
+}

--- a/drink/src/session/bundle.rs
+++ b/drink/src/session/bundle.rs
@@ -14,15 +14,15 @@ use super::error::SessionError;
 /// - `deploy_bundle_and`
 /// - `upload_bundle`
 /// - `upload_bundle_and`
-pub struct ContractBundle {
+pub struct ContractFile {
     /// WASM blob of the contract
-    pub bytes: Vec<u8>,
+    pub wasm: Vec<u8>,
     /// Transcoder derived from the ABI/metadata
     pub transcoder: Rc<ContractMessageTranscoder>,
 }
 
-impl ContractBundle {
-    /// Load and parse the information in a `.contract` bundle under `path`, producing a `ContractBundle` struct.
+impl ContractFile {
+    /// Load and parse the information in a `.contract` bundle under `path`, producing a `ContractFile` struct.
     pub fn load<P>(path: P) -> Result<Self, SessionError>
     where
         P: AsRef<std::path::Path>,
@@ -40,25 +40,25 @@ impl ContractBundle {
 
         let transcoder = Rc::new(ContractMessageTranscoder::new(ink_metadata));
 
-        let bytes = metadata
+        let wasm = metadata
             .source
             .wasm
             .ok_or(SessionError::BundleLoadFailed(
                 "Failed to get the WASM blob from the contract file".to_string(),
             ))?
             .0;
-            
-        Ok(Self { bytes, transcoder })
+
+        Ok(Self { wasm, transcoder })
     }
 
-    /// Load the `.contract` bundle (`bundle_file`) located in the `project_dir`` working directory.
+    /// Load the `.contract` bundle (`contract_file_name`) located in the `project_dir`` working directory.
     ///
-    /// This is meant to be used predominantly by the `local_bundle!` macro.
-    pub fn local(project_dir: &str, bundle_file: String) -> Self {
+    /// This is meant to be used predominantly by the `local_contract_file!` macro.
+    pub fn local(project_dir: &str, contract_file_name: String) -> Self {
         let mut path = PathBuf::from(project_dir);
         path.push("target");
         path.push("ink");
-        path.push(bundle_file);
+        path.push(contract_file_name);
         Self::load(path).expect("Loading the local bundle failed")
     }
 }
@@ -66,9 +66,9 @@ impl ContractBundle {
 /// A convenience macro that allows you to load a bundle found in the target directory
 /// of the current project.
 #[macro_export]
-macro_rules! local_bundle {
+macro_rules! local_contract_file {
     () => {
-        drink::session::ContractBundle::local(
+        drink::session::ContractFile::local(
             env!("CARGO_MANIFEST_DIR"),
             env!("CARGO_CRATE_NAME").to_owned() + ".contract",
         )

--- a/drink/src/session/error.rs
+++ b/drink/src/session/error.rs
@@ -36,4 +36,7 @@ pub enum SessionError {
     /// There is no registered transcoder to encode/decode messages for the called contract.
     #[error("Missing transcoder")]
     NoTranscoder,
+    /// Bundle loading and parsing has failed
+    #[error("Loading the contract bundle has failed: {0}")]
+    BundleLoadFailed(String),
 }

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -36,15 +36,15 @@ mod tests {
 
     use drink::{
         runtime::MinimalRuntime,
-        session::{ContractFile, Session, NO_ARGS},
+        session::{ContractBundle, Session, NO_ARGS},
         local_contract_file,
     };
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
-        let contract = ContractFile::load("./target/ink/flipper.contract")?;
+        let contract = ContractBundle::load("./target/ink/flipper.contract")?;
         let init_value: bool = Session::<MinimalRuntime>::new()?
-            .deploy_contract_and(contract, "new", &["true"], vec![], None)?
+            .deploy_bundle_and(contract, "new", &["true"], vec![], None)?
             .call_and("get", NO_ARGS, None)?
             .last_call_return()
             .expect("Call was successful, so there should be a return")
@@ -59,7 +59,7 @@ mod tests {
     fn flipping() -> Result<(), Box<dyn Error>> {
         let contract = local_contract_file!();
         let init_value: bool = Session::<MinimalRuntime>::new()?
-            .deploy_contract_and(contract, "new", &["true"], vec![], None)?
+            .deploy_bundle_and(contract, "new", &["true"], vec![], None)?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -32,28 +32,19 @@ mod flipper {
 
 #[cfg(test)]
 mod tests {
-    use std::{error::Error, fs, path::PathBuf, rc::Rc};
+    use std::{error::Error};
 
     use drink::{
         runtime::MinimalRuntime,
-        session::{contract_transcode::ContractMessageTranscoder, Session, NO_ARGS},
+        session::{ContractBundle, Session, NO_ARGS},
+        local_bundle,
     };
-
-    fn transcoder() -> Rc<ContractMessageTranscoder> {
-        Rc::new(
-            ContractMessageTranscoder::load(PathBuf::from("./target/ink/flipper.json"))
-                .expect("Failed to create transcoder"),
-        )
-    }
-
-    fn bytes() -> Vec<u8> {
-        fs::read("./target/ink/flipper.wasm").expect("Failed to find or read contract file")
-    }
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
+        let contract = ContractBundle::load("./target/ink/flipper.contract")?;
         let init_value: bool = Session::<MinimalRuntime>::new()?
-            .deploy_and(bytes(), "new", &["true"], vec![], None, &transcoder())?
+            .deploy_bundle_and(contract, "new", &["true"], vec![], None)?
             .call_and("get", NO_ARGS, None)?
             .last_call_return()
             .expect("Call was successful, so there should be a return")
@@ -66,8 +57,9 @@ mod tests {
 
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
+        let contract = local_bundle!();
         let init_value: bool = Session::<MinimalRuntime>::new()?
-            .deploy_and(bytes(), "new", &["true"], vec![], None, &transcoder())?
+            .deploy_bundle_and(contract, "new", &["true"], vec![], None)?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -36,15 +36,15 @@ mod tests {
 
     use drink::{
         runtime::MinimalRuntime,
-        session::{ContractBundle, Session, NO_ARGS},
-        local_bundle,
+        session::{ContractFile, Session, NO_ARGS},
+        local_contract_file,
     };
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
-        let contract = ContractBundle::load("./target/ink/flipper.contract")?;
+        let contract = ContractFile::load("./target/ink/flipper.contract")?;
         let init_value: bool = Session::<MinimalRuntime>::new()?
-            .deploy_bundle_and(contract, "new", &["true"], vec![], None)?
+            .deploy_contract_and(contract, "new", &["true"], vec![], None)?
             .call_and("get", NO_ARGS, None)?
             .last_call_return()
             .expect("Call was successful, so there should be a return")
@@ -57,9 +57,9 @@ mod tests {
 
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
-        let contract = local_bundle!();
+        let contract = local_contract_file!();
         let init_value: bool = Session::<MinimalRuntime>::new()?
-            .deploy_bundle_and(contract, "new", &["true"], vec![], None)?
+            .deploy_contract_and(contract, "new", &["true"], vec![], None)?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?
             .call_and("flip", NO_ARGS, None)?


### PR DESCRIPTION
As simple as the title suggests. Instead of loading the `.wasm` blob and the `.json` metadata separately, you can now load the whole `.contract` file using one of:
```rust
ContractFile::load("some/path/to/your.contract")
local_contract_file!()
```
And pass them to the methods that work with bundles, which would be one of:
* `deploy_contract`
* `deploy_contract_and`
* `load_contract`
* `load_contract_and`

So, all in all, what you do in your tests is:
```rust
use drink::{
    local_contract_file,
    session::{ContractFile, Session}};

let contract = ContractFile::load("path/to/your.contract");
Session::<MinimalRuntime>::new()?.deploy_contract_and(contract, "new", NO_ARGS, vec![], None) /* ... */

// or:

Session::<MinimalRuntime>::new()?.deploy_contract_and(local_contract_file!(), "new", NO_ARGS, vec![], None) /* ... */
```