### PR TITLE
Timestamp manipulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.5.1"
+version = "0.5.2"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -54,4 +54,4 @@ sp-runtime-interface = { version = "19.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.5.1", path = "drink" }
+drink = { version = "0.5.2", path = "drink" }

--- a/drink/src/runtime/mod.rs
+++ b/drink/src/runtime/mod.rs
@@ -24,6 +24,7 @@ pub use pallet_contracts;
 /// Must contain at least system, balances and contracts pallets.
 pub trait Runtime:
     frame_system::Config
+    + pallet_timestamp::Config
     + pallet_balances::Config<Balance = u128>
     + pallet_contracts::Config<Currency = pallet_balances::Pallet<Self>>
 {


### PR DESCRIPTION
We provide two new methods to the `ChainApi` trait:
 - `get_timestamp`
 - `set_timestamp`

closes #69 