### PR TITLE
Fix CI. Make `call` and `call_with_address` return decoded results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "drink-cli"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "cargo_metadata 0.18.1",
  "contract-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.5.4"
+version = "0.6.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -56,5 +56,5 @@ sp-runtime-interface = { version = "19.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.5.4", path = "drink" }
-drink-test-macro = { version = "0.5.4", path = "drink/test-macro" }
+drink = { version = "0.6.0", path = "drink" }
+drink-test-macro = { version = "0.6.0", path = "drink/test-macro" }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: run build lint test_examples clean help
 
 EXAMPLES = ./examples
-EXAMPLES_PATHS := $(shell find $(EXAMPLES) -mindepth 1 -maxdepth 1 -type d)
+EXAMPLES_PATHS := $(shell find $(EXAMPLES) -mindepth 1 -maxdepth 2 -name Cargo.toml -exec dirname "{}" \;)
 EXAMPLES_TARGET = ./examples/target
 
 run: ## Run the project
@@ -17,7 +17,6 @@ lint: ## Run the linter
 test_examples: ## Run tests for the examples
 	@mkdir -p $(EXAMPLES_TARGET)
 	@for dir in $(EXAMPLES_PATHS); do \
-		if [ $$dir = $(EXAMPLES_TARGET) ]; then continue; fi; \
 		echo "Processing $$dir"; \
 		cargo test --quiet --manifest-path $$dir/Cargo.toml --release --target-dir $(EXAMPLES_TARGET) || exit 1; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ lint: ## Run the linter
 test_examples: ## Run tests for the examples
 	@mkdir -p $(EXAMPLES_TARGET)
 	@for dir in $(EXAMPLES_PATHS); do \
-		echo "Processing $$dir" ; \
-		cargo test --quiet --manifest-path $$dir/Cargo.toml --release --target-dir $(EXAMPLES_TARGET); \
+		if [ $$dir = $(EXAMPLES_TARGET) ]; then continue; fi; \
+		echo "Processing $$dir"; \
+		cargo test --quiet --manifest-path $$dir/Cargo.toml --release --target-dir $(EXAMPLES_TARGET) || exit 1; \
 	done
 
 clean: ## Clean all the workspace build files

--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -107,7 +107,7 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
     let address = contract.address.clone();
     match app_state
         .session
-        .call_with_address(address, &message, &args, None)
+        .call_with_address::<_, ()>(address, &message, &args, None)
     {
         Ok(result) => app_state.print(&format!("Result: {:?}", result)),
         Err(err) => app_state.print_error(&format!("Failed to call contract\n{err}")),

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -85,13 +85,13 @@ pub const NO_ARGS: &[String] = &[];
 /// # fn contract_bytes() -> Vec<u8> { vec![] }
 /// # fn bob() -> AccountId32 { AccountId32::new([0; 32]) }
 ///
-/// # fn main() -> Result<(), drink::session::error::SessionError> {
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// let mut session = Session::<MinimalRuntime>::new()?;
 /// let _address = session.deploy(contract_bytes(), "new", NO_ARGS, vec![], None, &get_transcoder())?;
-/// session.call("foo", NO_ARGS, None)?;
+/// let _result: u32 = session.call("foo", NO_ARGS, None)??;
 /// session.set_actor(bob());
-/// session.call("bar", NO_ARGS, None)?;
+/// session.call::<_, ()>("bar", NO_ARGS, None)??;
 /// # Ok(()) }
 /// ```
 ///

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -343,7 +343,9 @@ impl<R: Runtime> Session<R> {
         args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Self, SessionError> {
-        self.call_internal(None, message, args, endowment)
+        // We ignore result, so we can pass `()` as the message result type, which will never fail
+        // at decoding.
+        self.call_internal::<_, ()>(None, message, args, endowment)
             .map(|_| self)
     }
 
@@ -355,39 +357,41 @@ impl<R: Runtime> Session<R> {
         args: &[S],
         endowment: Option<Balance>,
     ) -> Result<Self, SessionError> {
-        self.call_internal(Some(address), message, args, endowment)
+        // We ignore result, so we can pass `()` as the message result type, which will never fail
+        // at decoding.
+        self.call_internal::<_, ()>(Some(address), message, args, endowment)
             .map(|_| self)
     }
 
-    /// Calls the last deployed contract. In case of a successful call, returns the decoded result.
-    pub fn call<S: AsRef<str> + Debug>(
+    /// Calls the last deployed contract. In case of a successful call, returns the encoded result.
+    pub fn call<S: AsRef<str> + Debug, T: Decode>(
         &mut self,
         message: &str,
         args: &[S],
         endowment: Option<Balance>,
-    ) -> Result<Vec<u8>, SessionError> {
-        self.call_internal(None, message, args, endowment)
+    ) -> Result<MessageResult<T>, SessionError> {
+        self.call_internal::<_, T>(None, message, args, endowment)
     }
 
-    /// Calls a contract with a given address. In case of a successful call, returns the decoded
+    /// Calls a contract with a given address. In case of a successful call, returns the encoded
     /// result.
-    pub fn call_with_address<S: AsRef<str> + Debug>(
+    pub fn call_with_address<S: AsRef<str> + Debug, T: Decode>(
         &mut self,
         address: AccountIdFor<R>,
         message: &str,
         args: &[S],
         endowment: Option<Balance>,
-    ) -> Result<Vec<u8>, SessionError> {
+    ) -> Result<MessageResult<T>, SessionError> {
         self.call_internal(Some(address), message, args, endowment)
     }
 
-    fn call_internal<S: AsRef<str> + Debug>(
+    fn call_internal<S: AsRef<str> + Debug, T: Decode>(
         &mut self,
         address: Option<AccountIdFor<R>>,
         message: &str,
         args: &[S],
         endowment: Option<Balance>,
-    ) -> Result<Vec<u8>, SessionError> {
+    ) -> Result<MessageResult<T>, SessionError> {
         let address = match address {
             Some(address) => address,
             None => self
@@ -419,7 +423,12 @@ impl<R: Runtime> Session<R> {
             Ok(exec_result) => {
                 let encoded = exec_result.data.clone();
                 self.call_returns.push(encoded.clone());
-                Ok(encoded)
+
+                MessageResult::<T>::decode(&mut encoded.as_slice()).map_err(|err| {
+                    SessionError::Decoding(format!(
+                        "Failed to decode the result of calling a contract: {err:?}",
+                    ))
+                })
             }
             Err(err) => Err(SessionError::CallFailed(*err)),
         };

--- a/examples/cross-contract-call-tracing/lib.rs
+++ b/examples/cross-contract-call-tracing/lib.rs
@@ -145,7 +145,7 @@ mod tests {
             session.deploy_bundle(BundleProvider::local()?, "new", NO_ARGS, vec![3], None)?;
         INNER_ADDRESS.with(|a| *a.borrow_mut() = Some(inner_address.clone()));
 
-        let value = session.call_with_address(
+        let value: u32 = session.call_with_address(
             outer_address,
             "outer_call",
             &[
@@ -154,10 +154,9 @@ mod tests {
                 "7",
             ],
             None,
-        )?;
-        let value = u32::decode(&mut value.as_slice()).expect("Failed to decode return value");
+        )??;
 
-        assert_eq!(value, value);
+        assert_eq!(value, 22);
 
         Ok(())
     }


### PR DESCRIPTION
CI:
 - Makefile should fail if any example fails
 - do not treat `target` directory as an example

Session:
 - make `call` and `call_with_address` return decoded results (`Vec<u8>` is useless)