### PR TITLE
Expose the `fn execute_with`

### DIFF
--- a/drink/src/chain_api.rs
+++ b/drink/src/chain_api.rs
@@ -81,6 +81,11 @@ pub trait ChainApi<R: Runtime> {
 
     /// Reset the events of the current block.
     fn reset_current_block_events(&mut self);
+
+    /// Execute the given closure with the inner externallities.
+    ///
+    /// Returns the result of the given closure.
+    fn execute_with<T>(&mut self, execute: impl FnOnce() -> T) -> T;
 }
 
 impl<R: Runtime> ChainApi<R> for Sandbox<R> {
@@ -153,6 +158,10 @@ impl<R: Runtime> ChainApi<R> for Sandbox<R> {
     fn reset_current_block_events(&mut self) {
         self.externalities
             .execute_with(|| frame_system::Pallet::<R>::reset_events())
+    }
+
+    fn execute_with<T>(&mut self, execute: impl FnOnce() -> T) -> T {
+        self.externalities.execute_with(execute)
     }
 }
 


### PR DESCRIPTION
Phala's ink contract needs some extra setup. Like below code:
```Rust
        #[drink::test]
        fn deploy_and_call_http_get() -> Result<(), Box<dyn std::error::Error>> {
            use drink_pink_runtime::PinkRuntime;
            let checker_bundle = BundleProvider::local()?;
            let mut session = Session::<PinkRuntime>::new()?;
            session.execute_with(|| {
                PinkRuntime::setup_cluster().expect("Failed to setup cluster");
            });
            let checker =
                session.deploy_bundle(checker_bundle, "default", NO_ARGS, vec![], None)?;
            let (status, _body): (u16, String) = session.call_with_address(
                checker.clone(),
                "http_get",
                &["\"https://httpbin.org/get\""],
                None,
            )??;
            assert_eq!(status, 200);
     }
```

So, is it OK to export the function `execute_with`?