### PR TITLE
Support determinism policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "drink-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cargo_metadata 0.18.1",
  "contract-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.7.0"
+version = "0.8.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -56,5 +56,5 @@ sp-runtime-interface = { version = "19.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.7.0", path = "drink" }
-drink-test-macro = { version = "0.7.0", path = "drink/test-macro" }
+drink = { version = "0.8.0", path = "drink" }
+drink-test-macro = { version = "0.8.0", path = "drink/test-macro" }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Check our helpful and verbose examples in the [examples](examples) directory.
 
 `drink` library is continuously published to [crates.io](https://crates.io/crates/drink), so you can use it in your project with either `cargo add drink` or by adding the following line to your `Cargo.toml`:
 ```toml
-drink = { version = "0.6" }
+drink = { version = "0.8" }
 ```
 
 Full library documentation is available at: https://docs.rs/drink.

--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -125,7 +125,8 @@ fn find_wasm_blob(cwd: &Path) -> Option<(String, PathBuf)> {
     let Some(file) = entries
         .into_iter()
         .filter_map(|e| e.ok())
-        .find(|e| e.path().extension().unwrap_or_default() == "wasm") else {
+        .find(|e| e.path().extension().unwrap_or_default() == "wasm")
+    else {
         return None;
     };
 

--- a/drink/src/sandbox/contract_api.rs
+++ b/drink/src/sandbox/contract_api.rs
@@ -126,6 +126,7 @@ impl<R: pallet_contracts::Config> Sandbox<R> {
     /// * `origin` - The sender of the contract call.
     /// * `gas_limit` - The gas limit for the contract call.
     /// * `storage_deposit_limit` - The storage deposit limit for the contract call.
+    #[allow(clippy::too_many_arguments)]
     pub fn call_contract(
         &mut self,
         address: AccountIdFor<R>,

--- a/drink/src/sandbox/contract_api.rs
+++ b/drink/src/sandbox/contract_api.rs
@@ -104,13 +104,14 @@ impl<R: pallet_contracts::Config> Sandbox<R> {
         contract_bytes: Vec<u8>,
         origin: AccountIdFor<R>,
         storage_deposit_limit: Option<BalanceOf<R>>,
+        determinism: Determinism,
     ) -> CodeUploadResult<<R as frame_system::Config>::Hash, BalanceOf<R>> {
         self.externalities.execute_with(|| {
             pallet_contracts::Pallet::<R>::bare_upload_code(
                 origin,
                 contract_bytes,
                 storage_deposit_limit,
-                Determinism::Enforced,
+                determinism,
             )
         })
     }
@@ -133,6 +134,7 @@ impl<R: pallet_contracts::Config> Sandbox<R> {
         origin: AccountIdFor<R>,
         gas_limit: Weight,
         storage_deposit_limit: Option<BalanceOf<R>>,
+        determinism: Determinism,
     ) -> ContractExecResult<BalanceOf<R>, EventRecordOf<R>> {
         self.externalities.execute_with(|| {
             pallet_contracts::Pallet::<R>::bare_call(
@@ -144,7 +146,7 @@ impl<R: pallet_contracts::Config> Sandbox<R> {
                 data,
                 DebugInfo::UnsafeDebug,
                 CollectEvents::UnsafeCollect,
-                Determinism::Enforced,
+                determinism,
             )
         })
     }
@@ -186,7 +188,12 @@ mod tests {
         let wasm_binary = compile_module("dummy");
         let hash = <<MinimalRuntime as frame_system::Config>::Hashing>::hash(&wasm_binary);
 
-        let result = sandbox.upload_contract(wasm_binary, MinimalRuntime::default_actor(), None);
+        let result = sandbox.upload_contract(
+            wasm_binary,
+            MinimalRuntime::default_actor(),
+            None,
+            Determinism::Enforced,
+        );
 
         assert!(result.is_ok());
         assert_eq!(hash, result.unwrap().code_hash);
@@ -258,12 +265,13 @@ mod tests {
             actor.clone(),
             DEFAULT_GAS_LIMIT,
             None,
+            Determinism::Enforced,
         );
         assert!(result.result.is_ok());
         assert!(!result.result.unwrap().did_revert());
 
         let events = result.events.expect("Drink should collect events");
-        assert!(events.len() == 2);
+        assert_eq!(events.len(), 2);
 
         assert_eq!(
             events[0].event,

--- a/examples/quick-start-with-drink/README.md
+++ b/examples/quick-start-with-drink/README.md
@@ -12,7 +12,7 @@ Drink is developed and tested with stable Rust 1.70 (see [toolchain file](../../
 
 You only need the `drink` library brought into your project:
 ```toml
-drink = { version = "0.6" }
+drink = { version = "0.8" }
 ```
 
 See [Cargo.toml](Cargo.toml) for a typical cargo setup of a single-contract project.


### PR DESCRIPTION
Closes #80 

I've put determinism policy setting to a field within `Session`, similarly to an actor and gas limit, so that common operations on `Session` objects don't get penalty of additional configuration.