### PR TITLE
Runtime creator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.8.0"
+version = "0.8.1"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -56,5 +56,5 @@ sp-runtime-interface = { version = "19.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.8.0", path = "drink" }
-drink-test-macro = { version = "0.8.0", path = "drink/test-macro" }
+drink = { version = "0.8.1", path = "drink" }
+drink-test-macro = { version = "0.8.1", path = "drink/test-macro" }

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -26,6 +26,8 @@ pub use mock::{mock_message, ContractMock, MessageMock, MockedCallResult, Select
 use pallet_contracts::debug::ExecResult;
 use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags};
 use parity_scale_codec::{Decode, Encode};
+/// Export pallets that are used in the minimal runtime.
+pub use {frame_support, frame_system, pallet_balances, pallet_contracts, pallet_timestamp};
 
 use crate::{
     errors::MessageResult,

--- a/drink/src/runtime.rs
+++ b/drink/src/runtime.rs
@@ -16,9 +16,7 @@ pub type AccountIdFor<R> = <R as frame_system::Config>::AccountId;
 pub type HashFor<R> = <R as frame_system::Config>::Hash;
 
 /// Export pallets that are used in the runtime.
-pub use frame_system;
-pub use pallet_balances;
-pub use pallet_contracts;
+pub use {frame_support, frame_system, pallet_balances, pallet_contracts, pallet_timestamp};
 
 /// A runtime to use.
 pub trait Runtime: frame_system::Config {

--- a/drink/src/runtime.rs
+++ b/drink/src/runtime.rs
@@ -15,9 +15,6 @@ pub type AccountIdFor<R> = <R as frame_system::Config>::AccountId;
 /// The type of a hash.
 pub type HashFor<R> = <R as frame_system::Config>::Hash;
 
-/// Export pallets that are used in the runtime.
-pub use {frame_support, frame_system, pallet_balances, pallet_contracts, pallet_timestamp};
-
 /// A runtime to use.
 pub trait Runtime: frame_system::Config {
     /// Initialize the storage at the genesis block.

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)] // `construct_macro` doesn't allow doc comments for the runtime type.
 
+#[macro_export]
 macro_rules! create_minimal_runtime {
     ($name:ident) => {
         create_minimal_runtime!($name, ());
@@ -11,6 +12,7 @@ mod construct_runtime {
 
     // ------------ Bring some common types into the scope -----------------------------------------
     use $crate::frame_support::{
+        construct_runtime,
         parameter_types,
         sp_runtime::{
             testing::H256,
@@ -23,7 +25,7 @@ mod construct_runtime {
     use $crate::runtime::pallet_contracts_debugging::DrinkDebug;
 
     // ------------ Define the runtime type as a collection of pallets -----------------------------
-    $crate::frame_support::construct_runtime!(
+    construct_runtime!(
         pub enum $name {
             System: $crate::frame_system,
             Balances: $crate::pallet_balances,
@@ -33,7 +35,7 @@ mod construct_runtime {
     );
 
     // ------------ Configure pallet system --------------------------------------------------------
-    impl frame_system::Config for $name {
+    impl $crate::frame_system::Config for $name {
         type BaseCallFilter = $crate::frame_support::traits::Everything;
         type BlockWeights = ();
         type BlockLength = ();
@@ -60,7 +62,7 @@ mod construct_runtime {
     }
 
     // ------------ Configure pallet balances ------------------------------------------------------
-    impl pallet_balances::Config for $name {
+    impl $crate::pallet_balances::Config for $name {
         type RuntimeEvent = RuntimeEvent;
         type WeightInfo = ();
         type Balance = u128;
@@ -77,7 +79,7 @@ mod construct_runtime {
     }
 
     // ------------ Configure pallet timestamp -----------------------------------------------------
-    impl pallet_timestamp::Config for $name {
+    impl $crate::pallet_timestamp::Config for $name {
         type Moment = u64;
         type OnTimestampSet = ();
         type MinimumPeriod = ConstU64<1>;
@@ -109,7 +111,7 @@ mod construct_runtime {
         pub MaxDelegateDependencies: u32 = 32;
     }
 
-    impl pallet_contracts::Config for $name {
+    impl $crate::pallet_contracts::Config for $name {
         type Time = Timestamp;
         type Randomness = SandboxRandomness;
         type Currency = Balances;

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -1,142 +1,161 @@
 #![allow(missing_docs)] // `construct_macro` doesn't allow doc comments for the runtime type.
 
+macro_rules! create_minimal_runtime {
+    ($name:ident) => {
+        create_minimal_runtime!($name, ());
+    };
+    ($name:ident, $chain_extension: ty) => {
+
+// ------------ Put all the boilerplate into an auxiliary module -----------------------------------
+mod construct_runtime {
+
+    // ------------ Bring some common types into the scope -----------------------------------------
+    use $crate::frame_support::{
+        parameter_types,
+        sp_runtime::{
+            testing::H256,
+            traits::{BlakeTwo256, Convert, IdentityLookup},
+            AccountId32, Perbill,
+        },
+        traits::{ConstBool, ConstU128, ConstU32, ConstU64, Currency, Randomness},
+        weights::Weight,
+    };
+    use $crate::runtime::pallet_contracts_debugging::DrinkDebug;
+
+    // ------------ Define the runtime type as a collection of pallets -----------------------------
+    $crate::frame_support::construct_runtime!(
+        pub enum $name {
+            System: $crate::frame_system,
+            Balances: $crate::pallet_balances,
+            Timestamp: $crate::pallet_timestamp,
+            Contracts: $crate::pallet_contracts,
+        }
+    );
+
+    // ------------ Configure pallet system --------------------------------------------------------
+    impl frame_system::Config for $name {
+        type BaseCallFilter = $crate::frame_support::traits::Everything;
+        type BlockWeights = ();
+        type BlockLength = ();
+        type Block = $crate::frame_system::mocking::MockBlockU32<$name>;
+        type RuntimeOrigin = RuntimeOrigin;
+        type RuntimeCall = RuntimeCall;
+        type Nonce = u64;
+        type Hash = H256;
+        type Hashing = BlakeTwo256;
+        type AccountId = AccountId32;
+        type Lookup = IdentityLookup<Self::AccountId>;
+        type RuntimeEvent = RuntimeEvent;
+        type BlockHashCount = ConstU32<250>;
+        type DbWeight = ();
+        type Version = ();
+        type PalletInfo = PalletInfo;
+        type AccountData = $crate::pallet_balances::AccountData<u128>;
+        type OnNewAccount = ();
+        type OnKilledAccount = ();
+        type SystemWeightInfo = ();
+        type SS58Prefix = ();
+        type OnSetCode = ();
+        type MaxConsumers = ConstU32<16>;
+    }
+
+    // ------------ Configure pallet balances ------------------------------------------------------
+    impl pallet_balances::Config for $name {
+        type RuntimeEvent = RuntimeEvent;
+        type WeightInfo = ();
+        type Balance = u128;
+        type DustRemoval = ();
+        type ExistentialDeposit = ConstU128<1>;
+        type AccountStore = System;
+        type ReserveIdentifier = [u8; 8];
+        type FreezeIdentifier = ();
+        type MaxLocks = ();
+        type MaxReserves = ();
+        type MaxHolds = ConstU32<1>;
+        type MaxFreezes = ();
+        type RuntimeHoldReason = RuntimeHoldReason;
+    }
+
+    // ------------ Configure pallet timestamp -----------------------------------------------------
+    impl pallet_timestamp::Config for $name {
+        type Moment = u64;
+        type OnTimestampSet = ();
+        type MinimumPeriod = ConstU64<1>;
+        type WeightInfo = ();
+    }
+
+    // ------------ Configure pallet contracts -----------------------------------------------------
+    pub enum SandboxRandomness {}
+    impl Randomness<H256, u32> for SandboxRandomness {
+        fn random(_subject: &[u8]) -> (H256, u32) {
+            unreachable!("No randomness")
+        }
+    }
+
+    type BalanceOf = <Balances as Currency<AccountId32>>::Balance;
+    impl Convert<Weight, BalanceOf> for $name {
+        fn convert(w: Weight) -> BalanceOf {
+            w.ref_time().into()
+        }
+    }
+
+    parameter_types! {
+        pub SandboxSchedule: $crate::pallet_contracts::Schedule<$name> = {
+            <$crate::pallet_contracts::Schedule<$name>>::default()
+        };
+        pub DeletionWeightLimit: Weight = Weight::zero();
+        pub DefaultDepositLimit: BalanceOf = 10_000_000;
+        pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
+        pub MaxDelegateDependencies: u32 = 32;
+    }
+
+    impl pallet_contracts::Config for $name {
+        type Time = Timestamp;
+        type Randomness = SandboxRandomness;
+        type Currency = Balances;
+        type RuntimeEvent = RuntimeEvent;
+        type RuntimeCall = RuntimeCall;
+        type CallFilter = ();
+        type WeightPrice = Self;
+        type WeightInfo = ();
+        type ChainExtension = $chain_extension;
+        type Schedule = SandboxSchedule;
+        type CallStack = [$crate::pallet_contracts::Frame<Self>; 5];
+        type DepositPerByte = ConstU128<1>;
+        type DepositPerItem = ConstU128<1>;
+        type AddressGenerator = $crate::pallet_contracts::DefaultAddressGenerator;
+        type MaxCodeLen = ConstU32<{ 123 * 1024 }>;
+        type MaxStorageKeyLen = ConstU32<128>;
+        type UnsafeUnstableInterface = ConstBool<false>;
+        type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
+        type Migrations = ();
+        type DefaultDepositLimit = DefaultDepositLimit;
+        type Debug = DrinkDebug;
+        type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
+        type MaxDelegateDependencies = MaxDelegateDependencies;
+        type RuntimeHoldReason = RuntimeHoldReason;
+        type Environment = ();
+    }
+}
+
+// ------------ Export runtime type itself, pallets and useful types from the auxiliary module -----
+pub use construct_runtime::{
+    $name, Balances, Contracts, PalletInfo, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
+    RuntimeOrigin, System, Timestamp,
+};
+    };
+}
+
+create_minimal_runtime!(MinimalRuntime);
+
 use std::time::SystemTime;
 
-use frame_metadata::RuntimeMetadataPrefixed;
 use frame_support::{
-    parameter_types,
-    sp_runtime::{
-        testing::H256,
-        traits::{BlakeTwo256, Convert, Dispatchable, IdentityLookup},
-        AccountId32, BuildStorage, Perbill, Storage,
-    },
-    traits::{ConstBool, ConstU128, ConstU32, ConstU64, Currency, Hooks, Randomness},
-    weights::Weight,
-};
-// Re-export all pallets.
-pub use frame_system;
-use frame_system::{pallet_prelude::BlockNumberFor, Config};
-pub use pallet_balances;
-pub use pallet_contracts;
-use pallet_contracts::{DefaultAddressGenerator, Frame, Schedule};
-pub use pallet_timestamp;
-
-use crate::{
-    runtime::{pallet_contracts_debugging::DrinkDebug, AccountIdFor},
-    Runtime,
+    sp_runtime::{testing::H256, traits::Dispatchable, AccountId32, BuildStorage, Storage},
+    traits::Hooks,
 };
 
-type Block = frame_system::mocking::MockBlockU32<MinimalRuntime>;
-
-frame_support::construct_runtime!(
-    pub enum MinimalRuntime {
-        System: frame_system,
-        Balances: pallet_balances,
-        Timestamp: pallet_timestamp,
-        Contracts: pallet_contracts,
-    }
-);
-
-impl frame_system::Config for MinimalRuntime {
-    type BaseCallFilter = frame_support::traits::Everything;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type Block = Block;
-    type RuntimeOrigin = RuntimeOrigin;
-    type RuntimeCall = RuntimeCall;
-    type Nonce = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = AccountId32;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type RuntimeEvent = RuntimeEvent;
-    type BlockHashCount = ConstU32<250>;
-    type DbWeight = ();
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = pallet_balances::AccountData<u128>;
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = ();
-    type OnSetCode = ();
-    type MaxConsumers = ConstU32<16>;
-}
-
-impl pallet_balances::Config for MinimalRuntime {
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = ();
-    type Balance = u128;
-    type DustRemoval = ();
-    type ExistentialDeposit = ConstU128<1>;
-    type AccountStore = System;
-    type ReserveIdentifier = [u8; 8];
-    type FreezeIdentifier = ();
-    type MaxLocks = ();
-    type MaxReserves = ();
-    type MaxHolds = ConstU32<1>;
-    type MaxFreezes = ();
-    type RuntimeHoldReason = RuntimeHoldReason;
-}
-
-impl pallet_timestamp::Config for MinimalRuntime {
-    type Moment = u64;
-    type OnTimestampSet = ();
-    type MinimumPeriod = ConstU64<1>;
-    type WeightInfo = ();
-}
-
-pub enum SandboxRandomness {}
-impl Randomness<H256, u32> for SandboxRandomness {
-    fn random(_subject: &[u8]) -> (H256, u32) {
-        todo!("No randomness")
-    }
-}
-
-type BalanceOf = <Balances as Currency<AccountId32>>::Balance;
-impl Convert<Weight, BalanceOf> for MinimalRuntime {
-    fn convert(w: Weight) -> BalanceOf {
-        w.ref_time().into()
-    }
-}
-
-parameter_types! {
-    pub SandboxSchedule: Schedule<MinimalRuntime> = {
-        <Schedule<MinimalRuntime>>::default()
-    };
-    pub DeletionWeightLimit: Weight = Weight::zero();
-    pub DefaultDepositLimit: BalanceOf = 10_000_000;
-    pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
-    pub MaxDelegateDependencies: u32 = 32;
-}
-
-impl pallet_contracts::Config for MinimalRuntime {
-    type Time = Timestamp;
-    type Randomness = SandboxRandomness;
-    type Currency = Balances;
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeCall = RuntimeCall;
-    type CallFilter = ();
-    type WeightPrice = Self;
-    type WeightInfo = ();
-    type ChainExtension = ();
-    type Schedule = SandboxSchedule;
-    type CallStack = [Frame<Self>; 5];
-    type DepositPerByte = ConstU128<1>;
-    type DepositPerItem = ConstU128<1>;
-    type AddressGenerator = DefaultAddressGenerator;
-    type MaxCodeLen = ConstU32<{ 123 * 1024 }>;
-    type MaxStorageKeyLen = ConstU32<128>;
-    type UnsafeUnstableInterface = ConstBool<false>;
-    type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
-    type Migrations = ();
-    type DefaultDepositLimit = DefaultDepositLimit;
-    type Debug = DrinkDebug;
-    type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
-    type MaxDelegateDependencies = MaxDelegateDependencies;
-    type RuntimeHoldReason = RuntimeHoldReason;
-    type Environment = ();
-}
+use crate::{AccountIdFor, Runtime, RuntimeMetadataPrefixed};
 
 /// Default initial balance for the default account.
 pub const INITIAL_BALANCE: u128 = 1_000_000_000_000_000;
@@ -149,7 +168,10 @@ impl Runtime for MinimalRuntime {
         .assimilate_storage(storage)
     }
 
-    fn initialize_block(height: BlockNumberFor<Self>, parent_hash: H256) -> Result<(), String> {
+    fn initialize_block(
+        height: frame_system::pallet_prelude::BlockNumberFor<Self>,
+        parent_hash: H256,
+    ) -> Result<(), String> {
         System::reset_events();
         System::initialize(&height, &parent_hash, &Default::default());
 
@@ -168,7 +190,9 @@ impl Runtime for MinimalRuntime {
         Ok(())
     }
 
-    fn finalize_block(height: BlockNumberFor<Self>) -> Result<H256, String> {
+    fn finalize_block(
+        height: frame_system::pallet_prelude::BlockNumberFor<Self>,
+    ) -> Result<H256, String> {
         Contracts::on_finalize(height);
         Timestamp::on_finalize(height);
         Balances::on_finalize(height);
@@ -186,7 +210,7 @@ impl Runtime for MinimalRuntime {
 
     fn convert_account_to_origin(
         account: AccountIdFor<Self>,
-    ) -> <<Self as Config>::RuntimeCall as Dispatchable>::RuntimeOrigin {
+    ) -> <<Self as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin {
         Some(account).into()
     }
 }

--- a/drink/src/sandbox/balance_api.rs
+++ b/drink/src/sandbox/balance_api.rs
@@ -2,10 +2,7 @@
 use frame_support::{sp_runtime::DispatchError, traits::fungible::Mutate};
 
 use super::Sandbox;
-use crate::{
-    runtime::{AccountIdFor, *},
-    BalanceOf,
-};
+use crate::{runtime::AccountIdFor, BalanceOf};
 
 impl<R: pallet_balances::Config> Sandbox<R> {
     /// Mint tokens to an account.


### PR DESCRIPTION
We introduce a new macro `create_minimal_runtime`, which generates a minimal runtime with custom name and custom chain extension parameter. It can be used outside drink as well, but you also have to add `frame-system` and `frame-support` as dependencies (due to how `construct_runtime` macro works...).

This is a prerequisite for supporting chain extensions in drink.