### PR TITLE
Accessing emitted events

### DIFF
--- a/drink-cli/src/executor/contract.rs
+++ b/drink-cli/src/executor/contract.rs
@@ -93,7 +93,7 @@ pub fn deploy(app_state: &mut AppState, constructor: String, args: Vec<String>, 
         Err(err) => app_state.print_error(&format!("Failed to deploy contract\n{err}")),
     }
 
-    if let Some(info) = app_state.session.last_deploy_result() {
+    if let Some(info) = app_state.session.record().deploy_results().last() {
         app_state.print(&format_contract_action(info));
     }
 }
@@ -113,7 +113,7 @@ pub fn call(app_state: &mut AppState, message: String, args: Vec<String>) {
         Err(err) => app_state.print_error(&format!("Failed to call contract\n{err}")),
     };
 
-    if let Some(info) = app_state.session.last_call_result() {
+    if let Some(info) = app_state.session.record().call_results().last() {
         app_state.print(&format_contract_action(info))
     }
 }

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![warn(missing_docs)]
 
+extern crate core;
+
 mod bundle;
 pub mod errors;
 mod mock;

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![warn(missing_docs)]
 
-extern crate core;
-
 mod bundle;
 pub mod errors;
 mod mock;

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -264,6 +264,7 @@ impl<R: RuntimeWithContracts> Session<R> {
             .encode(constructor, args)
             .map_err(|err| SessionError::Encoding(err.to_string()))?;
 
+        self.record.start_recording_events(&mut self.sandbox);
         let result = self.sandbox.deploy_contract(
             contract_bytes,
             endowment.unwrap_or_default(),
@@ -273,6 +274,7 @@ impl<R: RuntimeWithContracts> Session<R> {
             self.gas_limit,
             None,
         );
+        self.record.stop_recording_events(&mut self.sandbox);
 
         let ret = match &result.result {
             Ok(exec_result) if exec_result.result.did_revert() => {
@@ -439,6 +441,7 @@ impl<R: RuntimeWithContracts> Session<R> {
             .encode(message, args)
             .map_err(|err| SessionError::Encoding(err.to_string()))?;
 
+        self.record.start_recording_events(&mut self.sandbox);
         let result = self.sandbox.call_contract(
             address,
             endowment.unwrap_or_default(),
@@ -448,6 +451,7 @@ impl<R: RuntimeWithContracts> Session<R> {
             None,
             self.determinism,
         );
+        self.record.stop_recording_events(&mut self.sandbox);
 
         let ret = match &result.result {
             Ok(exec_result) if exec_result.did_revert() => Err(SessionError::CallReverted),

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -229,6 +229,11 @@ impl<R: RuntimeWithContracts> Session<R> {
         &mut self.sandbox
     }
 
+    /// Returns a reference to the record of the session.
+    pub fn record(&self) -> &Record<R> {
+        &self.record
+    }
+
     /// Returns a reference for mocking API.
     pub fn mocking_api(&mut self) -> &mut impl MockingApi<R> {
         self

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -25,6 +25,7 @@ use crate::{
 
 pub mod error;
 pub mod mocking_api;
+mod record;
 mod transcoding;
 
 use error::SessionError;

--- a/drink/src/session/record.rs
+++ b/drink/src/session/record.rs
@@ -1,4 +1,7 @@
-use parity_scale_codec::Decode;
+use std::rc::Rc;
+
+use contract_transcode::{ContractMessageTranscoder, Value};
+use parity_scale_codec::{Decode, Encode};
 
 use crate::{
     errors::MessageResult,
@@ -192,6 +195,21 @@ impl EventBatch<MinimalRuntime> {
                     pallet_contracts::Event::<MinimalRuntime>::ContractEmitted { data, .. },
                 ) => Some(data.as_slice()),
                 _ => None,
+            })
+            .collect()
+    }
+
+    /// The same as `contract_events`, but decodes the events using the given transcoder.
+    pub fn contract_events_decoded(
+        &self,
+        transcoder: &Rc<ContractMessageTranscoder>,
+    ) -> Vec<Value> {
+        self.contract_events()
+            .into_iter()
+            .map(|data| {
+                transcoder
+                    .decode_contract_event(&mut data.encode().as_slice())
+                    .expect("Failed to decode contract event")
             })
             .collect()
     }

--- a/drink/src/session/record.rs
+++ b/drink/src/session/record.rs
@@ -223,18 +223,14 @@ impl EventBatch<MinimalRuntime> {
             .map(|sig| sig.as_bytes().try_into().unwrap())
             .collect::<Vec<[u8; 32]>>();
 
-        println!("signature_topics: {:?}", signature_topics);
-
         self.contract_events()
             .into_iter()
             .filter_map(|mut data| {
-                println!("data: {:?}", data);
                 for signature_topic in &signature_topics {
-                    match transcoder.decode_contract_event(&signature_topic.into(), &mut data) {
-                        Ok(decoded) => return Some(decoded),
-                        Err(err) => {
-                            println!("err: {:?}", err);
-                        }
+                    if let Ok(decoded) =
+                        transcoder.decode_contract_event(&signature_topic.into(), &mut data)
+                    {
+                        return Some(decoded);
                     }
                 }
                 None

--- a/drink/src/session/record.rs
+++ b/drink/src/session/record.rs
@@ -1,0 +1,143 @@
+use crate::{
+    runtime::{minimal::RuntimeEvent, AccountIdFor, MinimalRuntime, RuntimeWithContracts},
+    session::BalanceOf,
+    EventRecordOf, Sandbox,
+};
+
+type ContractInstantiateResult<R> = pallet_contracts_primitives::ContractInstantiateResult<
+    AccountIdFor<R>,
+    BalanceOf<R>,
+    EventRecordOf<R>,
+>;
+type ContractExecResult<R> =
+    pallet_contracts_primitives::ContractExecResult<BalanceOf<R>, EventRecordOf<R>>;
+
+/// Data structure storing the results of contract interaction during a session.
+///
+/// # Naming convention
+///
+/// By `result` we mean the full result (enriched with some context information) of the contract
+/// interaction, like `ContractExecResult`. By `return` we mean the return value of the contract
+/// execution, like a value returned from a message or the address of a newly instantiated contract.
+#[derive(Default)]
+pub struct Record<R: RuntimeWithContracts> {
+    /// The results of contract instantiation.
+    deploy_results: Vec<ContractInstantiateResult<R>>,
+    /// The return values of contract instantiation (i.e. the addresses of the newly instantiated
+    /// contracts).
+    deploy_returns: Vec<AccountIdFor<R>>,
+
+    /// The results of contract calls.
+    call_results: Vec<ContractExecResult<R>>,
+    /// The return values of contract calls (in the SCALE-encoded form).
+    call_returns: Vec<Vec<u8>>,
+
+    /// The events emitted by the contracts.
+    event_batches: Vec<EventBatch<R>>,
+
+    block_events_so_far: Option<usize>,
+}
+
+// API for `Session` to record results and events related to contract interaction.
+impl<R: RuntimeWithContracts> Record<R> {
+    pub(super) fn push_deploy_result(&mut self, result: ContractInstantiateResult<R>) {
+        self.deploy_results.push(result);
+    }
+
+    pub(super) fn push_deploy_return(&mut self, return_value: AccountIdFor<R>) {
+        self.deploy_returns.push(return_value);
+    }
+
+    pub(super) fn push_call_result(&mut self, result: ContractExecResult<R>) {
+        self.call_results.push(result);
+    }
+
+    pub(super) fn push_call_return(&mut self, return_value: Vec<u8>) {
+        self.call_returns.push(return_value);
+    }
+
+    pub(super) fn start_recording_events(&mut self, sandbox: &mut Sandbox<R>) {
+        assert!(
+            self.block_events_so_far.is_none(),
+            "Already recording events"
+        );
+        self.block_events_so_far = Some(sandbox.events().len());
+    }
+
+    pub(super) fn stop_recording_events(&mut self, sandbox: &mut Sandbox<R>) {
+        let start = self
+            .block_events_so_far
+            .take()
+            .expect("Not recording events");
+        let end = sandbox.events().len();
+        let events = sandbox.events()[start..end].to_vec();
+        self.event_batches.push(EventBatch { events });
+    }
+}
+
+// API for the end user.
+impl<R: RuntimeWithContracts> Record<R> {
+    pub fn deploy_results(&self) -> &[ContractInstantiateResult<R>] {
+        &self.deploy_results
+    }
+
+    pub fn last_deploy_result(&self) -> &ContractInstantiateResult<R> {
+        self.deploy_results.last().expect("No deploy results")
+    }
+
+    pub fn deploy_returns(&self) -> &[AccountIdFor<R>] {
+        &self.deploy_returns
+    }
+
+    pub fn last_deploy_return(&self) -> &AccountIdFor<R> {
+        self.deploy_returns.last().expect("No deploy returns")
+    }
+
+    pub fn call_results(&self) -> &[ContractExecResult<R>] {
+        &self.call_results
+    }
+
+    pub fn last_call_result(&self) -> &ContractExecResult<R> {
+        self.call_results.last().expect("No call results")
+    }
+
+    pub fn call_returns(&self) -> &[Vec<u8>] {
+        &self.call_returns
+    }
+
+    pub fn last_call_return(&self) -> &[u8] {
+        self.call_returns.last().expect("No call returns")
+    }
+
+    pub fn event_batches(&self) -> &[EventBatch<R>] {
+        &self.event_batches
+    }
+
+    pub fn last_event_batch(&self) -> &EventBatch<R> {
+        self.event_batches.last().expect("No event batches")
+    }
+}
+
+pub struct EventBatch<R: frame_system::Config> {
+    events: Vec<EventRecordOf<R>>,
+}
+
+impl<R: frame_system::Config> EventBatch<R> {
+    pub fn all_events(&self) -> &[EventRecordOf<R>] {
+        &self.events
+    }
+}
+
+impl EventBatch<MinimalRuntime> {
+    pub fn contract_events(&self) -> Vec<&[u8]> {
+        self.events
+            .iter()
+            .filter_map(|event| match &event.event {
+                RuntimeEvent::Contracts(
+                    pallet_contracts::Event::<MinimalRuntime>::ContractEmitted { data, .. },
+                ) => Some(data.as_slice()),
+                _ => None,
+            })
+            .collect()
+    }
+}

--- a/examples/contract-events/Cargo.toml
+++ b/examples/contract-events/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 path = "lib.rs"
 
 [dependencies]
-ink = { version = "=4.2.1", default-features = false, features = ["ink-debug"] }
+ink = { version = "=5.0.0-rc", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/contract-events/Cargo.toml
+++ b/examples/contract-events/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "contract-events"
+authors = ["Cardinal"]
+edition = "2021"
+homepage = "https://alephzero.org"
+repository = "https://github.com/Cardinal-Cryptography/drink"
+version = "0.1.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+ink = { version = "=4.2.1", default-features = false, features = ["ink-debug"] }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+drink = { path = "../../drink" }
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []

--- a/examples/contract-events/README.md
+++ b/examples/contract-events/README.md
@@ -1,0 +1,29 @@
+# Contract events
+
+This example shows how we can extract events that were emitted by a contract.
+
+When you are working with a `Session` object, you can consult its `Record` - a data structure that collects all the results and events that have been produced while interacting with contracts.
+For example:
+```rust
+let mut session = Session::<MinimalRuntime>::new()?;
+// .. some contract interaction
+
+// `record` is a `Record` object that contains all the results and events that have been produced while interacting with contracts.
+let record = session.record();
+```
+
+Given a `Record` object, we can extract the results of the contract interaction:
+```rust
+// `deploy_returns` returns a vector of contract addresses that have been deployed during the session.
+let all_deployed_contracts = record.deploy_returns();
+// `last_call_return_decoded` returns the decoded return value of the last contract call.
+let last_call_value = record.last_call_return_decoded::<CustomType>();
+```
+
+as well as the events that have been emitted by contracts:
+```rust
+// `last_event_batch` returns the batch of runtime events that have been emitted during last contract interaction.
+let last_event_batch = record.last_event_batch();
+// We can filter out raw events emitted by contracts with `contract_events` method.
+let contract_events_data = last_event_batch.contract_events();
+```

--- a/examples/contract-events/lib.rs
+++ b/examples/contract-events/lib.rs
@@ -1,0 +1,68 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod flipper {
+    #[ink(event)]
+    pub struct Flipped {
+        new_value: bool,
+    }
+
+    #[ink(storage)]
+    pub struct Flipper {
+        value: bool,
+    }
+
+    impl Flipper {
+        #[ink(constructor)]
+        pub fn new(init: bool) -> Self {
+            Self { value: init }
+        }
+
+        #[ink(message)]
+        pub fn flip(&mut self) {
+            self.value = !self.value;
+            self.env().emit_event(Flipped {
+                new_value: self.value,
+            });
+        }
+
+        #[ink(message)]
+        pub fn get(&self) -> bool {
+            self.value
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use drink::{
+        runtime::MinimalRuntime,
+        session::{Session, NO_ARGS},
+    };
+
+    #[drink::contract_bundle_provider]
+    enum BundleProvider {}
+
+    #[drink::test]
+    fn we_can_inspect_emitted_events() -> Result<(), Box<dyn Error>> {
+        let bundle = BundleProvider::local()?;
+
+        let events = Session::<MinimalRuntime>::new()?
+            .deploy_bundle_and(bundle, "new", &["false"], vec![], None)?
+            .call_and("flip", NO_ARGS, None)?
+            .last_call_result()
+            .expect("Call was successful, so there should be a return")
+            .events
+            .as_ref()
+            .expect("Drink is collecting events")
+            .clone();
+
+        for event in events {
+            println!("Event: {:?}", event);
+        }
+
+        Ok(())
+    }
+}

--- a/examples/contract-events/lib.rs
+++ b/examples/contract-events/lib.rs
@@ -39,7 +39,7 @@ mod tests {
 
     use drink::{
         runtime::MinimalRuntime,
-        session::{Session, NO_ARGS},
+        session::{Session, NO_ARGS, NO_ENDOWMENT},
     };
 
     #[drink::contract_bundle_provider]
@@ -49,13 +49,17 @@ mod tests {
     fn we_can_inspect_emitted_events() -> Result<(), Box<dyn Error>> {
         let bundle = BundleProvider::local()?;
 
+        // Firstly, we deploy the contract and call its `flip` method.
         let mut session = Session::<MinimalRuntime>::new()?;
-        session.deploy_bundle(bundle.clone(), "new", &["false"], vec![], None)?;
-        session.call("flip", NO_ARGS, None)??;
+        session.deploy_bundle(bundle.clone(), "new", &["false"], vec![], NO_ENDOWMENT)?;
+        session.call("flip", NO_ARGS, NO_ENDOWMENT)??;
 
+        // Now we can inspect the emitted events.
         let record = session.record();
         let contract_events = record
             .last_event_batch()
+            // We can use the `contract_events_decoded` method to decode the events into
+            // `contract_transcode::Value` objects.
             .contract_events_decoded(&bundle.transcoder);
 
         assert_eq!(contract_events.len(), 1);

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -48,8 +48,8 @@ mod tests {
         let init_value: bool = Session::<MinimalRuntime>::new()?
             .deploy_bundle_and(contract, "new", &["true"], NO_SALT, NO_ENDOWMENT)?
             .call_and("get", NO_ARGS, NO_ENDOWMENT)?
-            .last_call_return()
-            .expect("Call was successful, so there should be a return")
+            .record()
+            .last_call_return_decoded()?
             .expect("Call was successful");
 
         assert_eq!(init_value, true);
@@ -66,8 +66,8 @@ mod tests {
             .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
             .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
             .call_and("get", NO_ARGS, NO_ENDOWMENT)?
-            .last_call_return()
-            .expect("Call was successful, so there should be a return")
+            .record()
+            .last_call_return_decoded()?
             .expect("Call was successful");
 
         assert_eq!(init_value, false);

--- a/examples/mocking/lib.rs
+++ b/examples/mocking/lib.rs
@@ -67,8 +67,8 @@ mod tests {
         let result: (u8, u8) = session
             .deploy_bundle_and(BundleProvider::local()?, "new", NO_ARGS, NO_SALT, None)?
             .call_and("forward_call", &[mock_address.to_string()], NO_ENDOWMENT)?
-            .last_call_return()
-            .expect("Call was successful, so there should be a return")
+            .record()
+            .last_call_return_decoded()?
             .expect("Call was successful");
         assert_eq!(result, RETURN_VALUE);
 

--- a/examples/quick-start-with-drink/lib.rs
+++ b/examples/quick-start-with-drink/lib.rs
@@ -134,16 +134,13 @@ mod tests {
         )?;
 
         // `deploy_bundle` returns just a contract address. If we are interested in more details
-        // about last operation (either deploy or call), we can use the `last_deploy_result`
-        // (or analogously `last_call_result`) method, which will provide us with a full report
-        // from the last contract interaction.
+        // about last operation (either deploy or call), we can get a `Record` object and use its
+        // `last_deploy_result` (or analogously `last_call_result`) method, which will provide us
+        // with a full report from the last contract interaction.
         //
         // In particular, we can get the decoded debug buffer from the contract. The buffer is
         // just a vector of bytes, which we can decode using the `decode_debug_buffer` function.
-        let decoded_buffer = &session
-            .last_deploy_result()
-            .expect("The deployment succeeded, so there should be a result available")
-            .debug_message;
+        let decoded_buffer = &session.record().last_deploy_result().debug_message;
         let encoded_buffer = decode_debug_buffer(decoded_buffer);
 
         assert_eq!(encoded_buffer, vec!["Initializing contract with: `true`"]);


### PR DESCRIPTION
Implementing https://github.com/orgs/inkdevhub/projects/2/views/1?pane=issue&itemId=34267897

In order to simplify a bit `Session` object, we introduce `Record` type that collects all the results, returns and events that have been produced by contract interactions during a session.