### PR TITLE
Implement Runtime with blanket impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "drink-cli"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.8.6"
+version = "0.8.7"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -57,5 +57,5 @@ sp-runtime-interface = { version = "24.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.8.6", path = "drink" }
-drink-test-macro = { version = "0.8.6", path = "drink/test-macro" }
+drink = { version = "0.8.7", path = "drink" }
+drink-test-macro = { version = "0.8.7", path = "drink/test-macro" }

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -2,7 +2,6 @@
 //! a running node.
 
 #![warn(missing_docs)]
-#![recursion_limit = "1024"]
 
 mod bundle;
 pub mod errors;

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -2,6 +2,7 @@
 //! a running node.
 
 #![warn(missing_docs)]
+#![recursion_limit = "1024"]
 
 mod bundle;
 pub mod errors;

--- a/drink/src/runtime.rs
+++ b/drink/src/runtime.rs
@@ -5,7 +5,7 @@ pub mod minimal;
 pub mod pallet_contracts_debugging;
 
 pub use frame_metadata::RuntimeMetadataPrefixed;
-use frame_support::sp_runtime::{traits::Dispatchable, Storage};
+use frame_support::sp_runtime::Storage;
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use minimal::MinimalRuntime;
 
@@ -39,14 +39,6 @@ pub trait Runtime: frame_system::Config {
 
     /// Default actor for the runtime.
     fn default_actor() -> AccountIdFor<Self>;
-
-    /// Metadata of the runtime.
-    fn get_metadata() -> RuntimeMetadataPrefixed;
-
-    /// Convert an account to an call origin.
-    fn convert_account_to_origin(
-        account: AccountIdFor<Self>,
-    ) -> <<Self as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin;
 }
 
 /// Convenient umbrella trait for `Runtime + pallet_contracts::Config`

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -200,10 +200,7 @@ mod construct_runtime {
 }
 
 // ------------ Export runtime type itself, pallets and useful types from the auxiliary module -----
-pub use construct_runtime::{
-    $name, Balances, Contracts, PalletInfo, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
-    RuntimeOrigin, System, Timestamp, INITIAL_BALANCE,
-};
+pub use construct_runtime::*;
     };
 }
 

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -144,14 +144,14 @@ create_minimal_runtime!(MinimalRuntime);
 use std::time::SystemTime;
 
 use frame_support::{
-    sp_runtime::{BuildStorage, Storage},
+    sp_runtime::{traits::Header, BuildStorage, Storage},
     traits::Hooks,
 };
 
-use crate::runtime::{AccountIdFor, Runtime};
-use crate::AccountId32;
-use frame_support::sp_runtime::traits::Header; 
-
+use crate::{
+    runtime::{AccountIdFor, Runtime},
+    AccountId32,
+};
 
 /// Default initial balance for the default account.
 pub const INITIAL_BALANCE: u128 = 1_000_000_000_000_000;
@@ -161,12 +161,12 @@ type BalancesOf<T> = pallet_balances::Pallet<T>;
 type TimestampOf<T> = pallet_timestamp::Pallet<T>;
 type ContractsOf<T> = pallet_contracts::Pallet<T>;
 
-impl<T> Runtime for T 
+impl<T> Runtime for T
 where
-T:  pallet_balances::Config + pallet_timestamp::Config + pallet_contracts::Config,
-<T as frame_system::Config>::AccountId: From<AccountId32>,
-<T as pallet_balances::Config>::Balance: From<u128>,
-<T as pallet_timestamp::Config>::Moment: From<u64>,
+    T: pallet_balances::Config + pallet_timestamp::Config + pallet_contracts::Config,
+    <T as frame_system::Config>::AccountId: From<AccountId32>,
+    <T as pallet_balances::Config>::Balance: From<u128>,
+    <T as pallet_timestamp::Config>::Moment: From<u64>,
 {
     fn initialize_storage(storage: &mut Storage) -> Result<(), String> {
         pallet_balances::GenesisConfig::<Self> {
@@ -187,7 +187,7 @@ T:  pallet_balances::Config + pallet_timestamp::Config + pallet_contracts::Confi
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .expect("Time went backwards")
                 .as_secs()
-                .into()
+                .into(),
         );
         TimestampOf::<T>::on_initialize(height);
         ContractsOf::<T>::on_initialize(height);

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -200,7 +200,10 @@ mod construct_runtime {
 }
 
 // ------------ Export runtime type itself, pallets and useful types from the auxiliary module -----
-pub use construct_runtime::*;
+pub use construct_runtime::{
+    $name, Balances, Contracts, PalletInfo, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
+    RuntimeOrigin, System, Timestamp, INITIAL_BALANCE,
+};
     };
 }
 

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -14,6 +14,8 @@ scale-info = { version = "2.6", default-features = false, features = ["derive"],
 
 [dev-dependencies]
 drink = { path = "../../drink" }
+# Use to test against custom Runtime
+pallet-contracts-mock-network = "3.0.0"
 
 [lib]
 path = "lib.rs"

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -72,7 +72,7 @@ mod tests {
         Ok(())
     }
 
-    #[drink::test(runtime = pallet_contract_mock_network::parachain::Runtime)]
+    #[drink::test(runtime = pallet_contracts_mock_network::parachain::Runtime)]
     fn test_flipping_with_custom_runtime(mut session: Session) -> Result<(), Box<dyn std::error::Error>> {
         let contract = BundleProvider::Flipper.bundle()?;
         let init_value: bool = session

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -71,4 +71,25 @@ mod tests {
 
         Ok(())
     }
+
+    // #[drink::test(runtime = pallet_contract_mock_network::parachain::Runtime)]
+    #[drink::test]
+    fn test_flipping_with_custom_runtime(mut session: Session) -> Result<(), Box<dyn std::error::Error>> {
+        let contract = BundleProvider::Flipper.bundle()?;
+        let init_value: bool = session
+            .deploy_bundle_and(contract, "new", &["true"], NO_SALT, NO_ENDOWMENT)?
+            .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
+            .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
+            .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
+            .call_and("get", NO_ARGS, NO_ENDOWMENT)?
+            .record()
+            .last_call_return_decoded()?
+            .expect("Call was successful");
+
+        assert_eq!(init_value, false);
+
+        Ok(())
+    }
 }
+
+

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -72,8 +72,7 @@ mod tests {
         Ok(())
     }
 
-    // #[drink::test(runtime = pallet_contract_mock_network::parachain::Runtime)]
-    #[drink::test]
+    #[drink::test(runtime = pallet_contract_mock_network::parachain::Runtime)]
     fn test_flipping_with_custom_runtime(mut session: Session) -> Result<(), Box<dyn std::error::Error>> {
         let contract = BundleProvider::Flipper.bundle()?;
         let init_value: bool = session


### PR DESCRIPTION
Implement the Runtime trait for all struct that implements the required trait rather than doing it inside the macro.
This let us use existing runtime in our tests (as long as they satisfy  the requirements)
See added test.