### PR TITLE
Rename & update SandboxConfig trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0]
+
+- Rework Sandbox API to better support custom Runtime
+
 ## [Unreleased]
 
 # [0.13.0]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ crossterm = { version = "0.26.0" }
 darling = { version = "0.20.3" }
 parity-scale-codec = { version = "3.6.9" }
 parity-scale-codec-derive = { version = "3.6.9" }
+paste = { version = "1.0.7" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 ratatui = { version = "0.21.0" }

--- a/drink-cli/src/app_state/mod.rs
+++ b/drink-cli/src/app_state/mod.rs
@@ -1,7 +1,7 @@
 use std::{env, path::PathBuf};
 
 pub use contracts::{Contract, ContractIndex, ContractRegistry};
-use drink::{runtime::MinimalRuntime, session::Session, SandboxConfig, Weight, DEFAULT_GAS_LIMIT};
+use drink::{runtime::MinimalSandbox, session::Session, Sandbox, Weight, DEFAULT_GAS_LIMIT};
 use sp_core::crypto::AccountId32;
 pub use user_input::UserInput;
 
@@ -23,7 +23,7 @@ impl Default for ChainInfo {
     fn default() -> Self {
         Self {
             block_height: 0,
-            actor: MinimalRuntime::default_actor(),
+            actor: MinimalSandbox::default_actor(),
             gas_limit: DEFAULT_GAS_LIMIT,
         }
     }
@@ -69,7 +69,7 @@ impl Default for UiState {
 }
 
 pub struct AppState {
-    pub session: Session<MinimalRuntime>,
+    pub session: Session<MinimalSandbox>,
     pub chain_info: ChainInfo,
     pub ui_state: UiState,
     pub contracts: ContractRegistry,
@@ -78,7 +78,7 @@ pub struct AppState {
 impl AppState {
     pub fn new(cwd_override: Option<PathBuf>) -> Self {
         AppState {
-            session: Session::new().expect("Failed to create drinking session"),
+            session: Session::default(),
             chain_info: Default::default(),
             ui_state: UiState::new(cwd_override),
             contracts: Default::default(),

--- a/drink-cli/src/executor/mod.rs
+++ b/drink-cli/src/executor/mod.rs
@@ -5,7 +5,7 @@ use std::env;
 
 use anyhow::Result;
 use clap::Parser;
-use drink::Weight;
+use drink::{sandbox::prelude::*, Weight};
 use sp_core::crypto::AccountId32;
 
 use crate::{app_state::AppState, cli::CliCommand};
@@ -67,12 +67,7 @@ pub fn execute(app_state: &mut AppState) -> Result<()> {
 }
 
 fn build_blocks(app_state: &mut AppState, count: u32) {
-    app_state.chain_info.block_height = app_state
-        .session
-        .sandbox()
-        .build_blocks(count)
-        .expect("Failed to build block - chain is broken");
-
+    app_state.chain_info.block_height = app_state.session.sandbox().build_blocks(count);
     app_state.print(&format!("{count} blocks built"));
 }
 
@@ -80,7 +75,7 @@ fn add_tokens(app_state: &mut AppState, recipient: AccountId32, value: u128) -> 
     app_state
         .session
         .sandbox()
-        .mint_into(recipient.clone(), value)
+        .mint_into(&recipient, value)
         .map_err(|err| anyhow::format_err!("Failed to add token: {err:?}"))?;
     app_state.print(&format!("{value} tokens added to {recipient}",));
     Ok(())

--- a/drink/Cargo.toml
+++ b/drink/Cargo.toml
@@ -25,8 +25,9 @@ sp-externalities = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime-interface = { workspace = true }
 
-serde_json = { workspace = true, optional = true }
+paste = { workspace = true }
 scale-info = { workspace = true }
+serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 wat = { workspace = true }
 

--- a/drink/src/errors.rs
+++ b/drink/src/errors.rs
@@ -8,12 +8,6 @@ pub enum Error {
     /// Externalities could not be initialized.
     #[error("Failed to build storage: {0}")]
     StorageBuilding(String),
-    /// Block couldn't have been initialized.
-    #[error("Failed to initialize block: {0}")]
-    BlockInitialize(String),
-    /// Block couldn't have been finalized.
-    #[error("Failed to finalize block: {0}")]
-    BlockFinalize(String),
     /// Bundle loading and parsing has failed
     #[error("Loading the contract bundle has failed: {0}")]
     BundleLoadFailed(String),

--- a/drink/src/lib.rs
+++ b/drink/src/lib.rs
@@ -23,17 +23,15 @@ use pallet_contracts::{ContractExecResult, ContractInstantiateResult};
 #[cfg(feature = "session")]
 pub use session::mock::{mock_message, ContractMock, MessageMock, MockedCallResult, Selector};
 /// Export pallets that are used in the minimal runtime.
-pub use {frame_support, frame_system, pallet_balances, pallet_contracts, pallet_timestamp};
+pub use {
+    frame_support, frame_system, pallet_balances, pallet_contracts, pallet_timestamp, paste,
+    sp_externalities::Extension, sp_io::TestExternalities,
+};
 
-pub use crate::runtime::minimal::{self, MinimalRuntime};
-use crate::runtime::AccountIdFor;
+pub use crate::runtime::minimal::{self, MinimalSandbox};
 
 /// Alias for `frame-system`'s `RuntimeCall` type.
-pub type RuntimeCall<Runtime> = <Runtime as frame_system::Config>::RuntimeCall;
-
-/// Alias for `pallet-balances`'s Balance type.
-pub type BalanceOf<Runtime> =
-    <<Runtime as pallet_contracts::Config>::Currency as Inspect<AccountIdFor<Runtime>>>::Balance;
+pub type RuntimeCall<R> = <R as frame_system::Config>::RuntimeCall;
 
 /// Main result type for the drink crate.
 pub type DrinkResult<T> = std::result::Result<T, Error>;
@@ -43,6 +41,9 @@ pub type EventRecordOf<Runtime> = EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,
     <Runtime as frame_system::Config>::Hash,
 >;
+
+type BalanceOf<R> =
+    <<R as pallet_contracts::Config>::Currency as Inspect<AccountIdFor<R>>>::Balance;
 
 /// Copied from pallet-contracts.
 pub type ContractInstantiateResultFor<Runtime> =

--- a/drink/src/runtime.rs
+++ b/drink/src/runtime.rs
@@ -1,10 +1,10 @@
-//! Module containing the [`Runtime`](Runtime) trait and its example implementations. You can use
-//! `drink` with any runtime that implements the `Runtime` trait.
+//! Module containing a [`MinimalSandbox`] that implements the [`crate::Sandbox`] trait.
+//! Also contains debugging utilities for the contracts pallet.
 
 pub mod minimal;
 pub mod pallet_contracts_debugging;
 pub use frame_metadata::RuntimeMetadataPrefixed;
-pub use minimal::MinimalRuntime;
+pub use minimal::MinimalSandbox;
 
 /// The type of an account identifier.
 pub type AccountIdFor<R> = <R as frame_system::Config>::AccountId;

--- a/drink/src/runtime/minimal.rs
+++ b/drink/src/runtime/minimal.rs
@@ -1,94 +1,88 @@
 #![allow(missing_docs)] // `construct_macro` doesn't allow doc comments for the runtime type.
 
-/// The macro will generate an implementation of `drink::SandboxConfig` for the given runtime type.
-#[macro_export]
-macro_rules! impl_sandbox_config {
-    (
-        $( #[ $attr:meta ] )*
-        $vis:vis struct $name:ident {
-            runtime: $runtime:tt;
-            default_balance: $default_balance:expr;
-            default_actor: $default_actor:expr;
-        }
-    ) => {
-        $( #[ $attr ] )*
-        $vis struct $name;
-        impl_sandbox_config!($name, $runtime, $default_balance, $default_actor);
-    };
-    (
-        $name:ident, $runtime:tt, $default_balance:expr, $default_actor:expr
-    ) => {
-        impl $crate::SandboxConfig for $name {
-            type Runtime = $runtime;
+use std::time::SystemTime;
 
-            fn initialize_storage(storage: &mut $crate::frame_support::sp_runtime::Storage) -> Result<(), String> {
-                use $crate::frame_support::sp_runtime::BuildStorage;
-                $crate::pallet_balances::GenesisConfig::<$runtime> {
-                    balances: vec![(Self::default_actor(), $default_balance)],
-                }
-                .assimilate_storage(storage)
-            }
+use frame_support::{
+    sp_runtime::{
+        traits::{Header, One},
+        BuildStorage,
+    },
+    traits::Hooks,
+};
+use frame_system::pallet_prelude::BlockNumberFor;
+use sp_io::TestExternalities;
 
-            fn initialize_block(
-                height: $crate::frame_system::pallet_prelude::BlockNumberFor<$runtime>,
-                parent_hash: <$runtime as $crate::frame_system::Config>::Hash,
-            ) -> Result<(), String> {
-                use std::time::SystemTime;
-                use $crate::frame_support::traits::Hooks;
+/// A helper struct for initializing and finalizing blocks.
+pub struct BlockBuilder<T>(std::marker::PhantomData<T>);
 
-                $crate::frame_system::Pallet::<$runtime>::reset_events();
-                $crate::frame_system::Pallet::<$runtime>::initialize(&height, &parent_hash, &Default::default());
-                $crate::pallet_balances::Pallet::<$runtime>::on_initialize(height);
-                $crate::pallet_timestamp::Pallet::<$runtime>::set_timestamp(
-                    SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .expect("Time went backwards")
-                        .as_secs(),
-                );
-                $crate::pallet_timestamp::Pallet::<$runtime>::on_initialize(height);
-                $crate::pallet_contracts::Pallet::<$runtime>::on_initialize(height);
-                $crate::frame_system::Pallet::<$runtime>::note_finished_initialize();
-                Ok(())
-            }
+impl<
+        T: pallet_balances::Config + pallet_timestamp::Config<Moment = u64> + pallet_contracts::Config,
+    > BlockBuilder<T>
+{
+    /// Create a new externalities with the given balances.
+    pub fn new_ext(balances: Vec<(T::AccountId, T::Balance)>) -> TestExternalities {
+        let mut storage = frame_system::GenesisConfig::<T>::default()
+            .build_storage()
+            .unwrap();
 
-            fn finalize_block(
-                height: $crate::frame_system::pallet_prelude::BlockNumberFor<$runtime>,
-            ) -> Result<<$runtime as $crate::frame_system::Config>::Hash, String> {
-                use $crate::frame_support::traits::Hooks;
+        pallet_balances::GenesisConfig::<T> { balances }
+            .assimilate_storage(&mut storage)
+            .unwrap();
 
-                $crate::pallet_contracts::Pallet::<$runtime>::on_finalize(height);
-                $crate::pallet_timestamp::Pallet::<$runtime>::on_finalize(height);
-                $crate::pallet_balances::Pallet::<$runtime>::on_finalize(height);
-                Ok($crate::frame_system::Pallet::<$runtime>::finalize().hash())
-            }
+        let mut ext = TestExternalities::new(storage);
 
-            fn default_actor() -> $crate::runtime::AccountIdFor<$runtime> {
-                $default_actor
-            }
+        ext.execute_with(|| Self::initialize_block(BlockNumberFor::<T>::one(), Default::default()));
+        ext
+    }
 
-            fn get_metadata() -> $crate::runtime::RuntimeMetadataPrefixed {
-                $runtime::metadata()
-            }
+    /// Initialize a new block at particular height.
+    pub fn initialize_block(
+        height: frame_system::pallet_prelude::BlockNumberFor<T>,
+        parent_hash: <T as frame_system::Config>::Hash,
+    ) {
+        frame_system::Pallet::<T>::reset_events();
+        frame_system::Pallet::<T>::initialize(&height, &parent_hash, &Default::default());
+        pallet_balances::Pallet::<T>::on_initialize(height);
+        pallet_timestamp::Pallet::<T>::set_timestamp(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs(),
+        );
+        pallet_timestamp::Pallet::<T>::on_initialize(height);
+        pallet_contracts::Pallet::<T>::on_initialize(height);
+        frame_system::Pallet::<T>::note_finished_initialize();
+    }
 
-            fn convert_account_to_origin(
-                account: $crate::runtime::AccountIdFor<$runtime>,
-            ) -> <<$runtime as $crate::frame_system::Config>::RuntimeCall as $crate::frame_support::sp_runtime::traits::Dispatchable>::RuntimeOrigin {
-                Some(account).into()
-            }
-        }
-    };
+    /// Finalize a block at particular height.
+    pub fn finalize_block(
+        height: frame_system::pallet_prelude::BlockNumberFor<T>,
+    ) -> <T as frame_system::Config>::Hash {
+        pallet_contracts::Pallet::<T>::on_finalize(height);
+        pallet_timestamp::Pallet::<T>::on_finalize(height);
+        pallet_balances::Pallet::<T>::on_finalize(height);
+        frame_system::Pallet::<T>::finalize().hash()
+    }
 }
 
 /// Macro creating a minimal runtime with the given name. Optionally can take a chain extension
 /// type as a second argument.
 ///
-/// The new macro will automatically implement `drink::SandboxConfig`.
+/// The new macro will automatically implement `drink::Sandbox`.
 #[macro_export]
-macro_rules! create_minimal_runtime {
+macro_rules! create_minimal_sandbox {
     ($name:ident) => {
-        create_minimal_runtime!($name, ());
+        $crate::paste::paste! {
+            $crate::create_minimal_sandbox!($name, [<$name Runtime>], ());
+        }
     };
     ($name:ident, $chain_extension: ty) => {
+        $crate::paste::paste! {
+            $crate::create_minimal_sandbox!($name, [<$name Runtime>], $chain_extension);
+        }
+    };
+    ($sandbox:ident, $runtime:ident, $chain_extension: ty) => {
+
 
 // ------------ Put all the boilerplate into an auxiliary module -----------------------------------
 mod construct_runtime {
@@ -110,7 +104,7 @@ mod construct_runtime {
 
     // ------------ Define the runtime type as a collection of pallets -----------------------------
     construct_runtime!(
-        pub enum $name {
+        pub enum $runtime {
             System: $crate::frame_system,
             Balances: $crate::pallet_balances,
             Timestamp: $crate::pallet_timestamp,
@@ -120,15 +114,15 @@ mod construct_runtime {
 
     // ------------ Configure pallet system --------------------------------------------------------
     #[derive_impl($crate::frame_system::config_preludes::SolochainDefaultConfig as $crate::frame_system::DefaultConfig)]
-    impl $crate::frame_system::Config for $name {
-        type Block = $crate::frame_system::mocking::MockBlockU32<$name>;
+    impl $crate::frame_system::Config for $runtime {
+        type Block = $crate::frame_system::mocking::MockBlockU32<$runtime>;
         type Version = ();
         type BlockHashCount = ConstU32<250>;
-        type AccountData = $crate::pallet_balances::AccountData<<$name as $crate::pallet_balances::Config>::Balance>;
+        type AccountData = $crate::pallet_balances::AccountData<<$runtime as $crate::pallet_balances::Config>::Balance>;
     }
 
     // ------------ Configure pallet balances ------------------------------------------------------
-    impl $crate::pallet_balances::Config for $name {
+    impl $crate::pallet_balances::Config for $runtime {
         type RuntimeEvent = RuntimeEvent;
         type WeightInfo = ();
         type Balance = u128;
@@ -145,7 +139,7 @@ mod construct_runtime {
     }
 
     // ------------ Configure pallet timestamp -----------------------------------------------------
-    impl $crate::pallet_timestamp::Config for $name {
+    impl $crate::pallet_timestamp::Config for $runtime {
         type Moment = u64;
         type OnTimestampSet = ();
         type MinimumPeriod = ConstU64<1>;
@@ -161,15 +155,15 @@ mod construct_runtime {
     }
 
     type BalanceOf = <Balances as Currency<AccountId32>>::Balance;
-    impl Convert<Weight, BalanceOf> for $name {
+    impl Convert<Weight, BalanceOf> for $runtime {
         fn convert(w: Weight) -> BalanceOf {
             w.ref_time().into()
         }
     }
 
     parameter_types! {
-        pub SandboxSchedule: $crate::pallet_contracts::Schedule<$name> = {
-            <$crate::pallet_contracts::Schedule<$name>>::default()
+        pub SandboxSchedule: $crate::pallet_contracts::Schedule<$runtime> = {
+            <$crate::pallet_contracts::Schedule<$runtime>>::default()
         };
         pub DeletionWeightLimit: Weight = Weight::zero();
         pub DefaultDepositLimit: BalanceOf = 10_000_000;
@@ -177,7 +171,7 @@ mod construct_runtime {
         pub MaxDelegateDependencies: u32 = 32;
     }
 
-    impl $crate::pallet_contracts::Config for $name {
+    impl $crate::pallet_contracts::Config for $runtime {
         type Time = Timestamp;
         type Randomness = SandboxRandomness;
         type Currency = Balances;
@@ -211,18 +205,81 @@ mod construct_runtime {
 
     /// Default initial balance for the default account.
     pub const INITIAL_BALANCE: u128 = 1_000_000_000_000_000;
-    $crate::impl_sandbox_config!($name, $name, INITIAL_BALANCE, AccountId32::new([1u8; 32]));
+    pub const DEFAULT_ACCOUNT: AccountId32 = AccountId32::new([1u8; 32]);
+
+    pub struct $sandbox {
+        ext: $crate::TestExternalities,
+    }
+
+    impl ::std::default::Default for $sandbox {
+        fn default() -> Self {
+            let ext = $crate::minimal::BlockBuilder::<$runtime>::new_ext(vec![(
+                DEFAULT_ACCOUNT,
+                INITIAL_BALANCE,
+            )]);
+            Self { ext }
+        }
+    }
+
+    impl $crate::Sandbox for $sandbox {
+        type Runtime = $runtime;
+
+        fn execute_with<T>(&mut self, execute: impl FnOnce() -> T) -> T {
+            self.ext.execute_with(execute)
+        }
+
+        fn dry_run<T>(&mut self, action: impl FnOnce(&mut Self) -> T) -> T {
+            // Make a backup of the backend.
+            let backend_backup = self.ext.as_backend();
+            // Run the action, potentially modifying storage. Ensure, that there are no pending changes
+            // that would affect the reverted backend.
+            let result = action(self);
+            self.ext.commit_all().expect("Failed to commit changes");
+
+            // Restore the backend.
+            self.ext.backend = backend_backup;
+            result
+        }
+
+        fn register_extension<E: ::core::any::Any + $crate::Extension>(&mut self, ext: E) {
+            self.ext.register_extension(ext);
+        }
+
+        fn initialize_block(
+            height: $crate::frame_system::pallet_prelude::BlockNumberFor<Self::Runtime>,
+            parent_hash: <Self::Runtime as $crate::frame_system::Config>::Hash,
+        ) {
+            $crate::minimal::BlockBuilder::<Self::Runtime>::initialize_block(height, parent_hash)
+        }
+
+        fn finalize_block(
+            height: $crate::frame_system::pallet_prelude::BlockNumberFor<Self::Runtime>,
+        ) -> <Self::Runtime as $crate::frame_system::Config>::Hash {
+            $crate::minimal::BlockBuilder::<Self::Runtime>::finalize_block(height)
+        }
+
+        fn default_actor() -> $crate::runtime::AccountIdFor<Self::Runtime> {
+            DEFAULT_ACCOUNT
+        }
+
+        fn get_metadata() -> $crate::runtime::RuntimeMetadataPrefixed {
+            Self::Runtime::metadata()
+        }
+
+        fn convert_account_to_origin(
+            account: $crate::runtime::AccountIdFor<Self::Runtime>,
+        ) -> <<Self::Runtime as $crate::frame_system::Config>::RuntimeCall as $crate::frame_support::sp_runtime::traits::Dispatchable>::RuntimeOrigin {
+            Some(account).into()
+        }
+    }
 }
-
-
-
 
 // ------------ Export runtime type itself, pallets and useful types from the auxiliary module -----
 pub use construct_runtime::{
-    $name, Balances, Contracts, PalletInfo, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
+    $sandbox, $runtime, Balances, Contracts, PalletInfo, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
     RuntimeOrigin, System, Timestamp,
 };
     };
 }
 
-create_minimal_runtime!(MinimalRuntime);
+create_minimal_sandbox!(MinimalSandbox);

--- a/drink/src/sandbox/balance_api.rs
+++ b/drink/src/sandbox/balance_api.rs
@@ -2,13 +2,15 @@
 use frame_support::{sp_runtime::DispatchError, traits::fungible::Mutate};
 
 use super::Sandbox;
-use crate::{runtime::AccountIdFor, SandboxConfig};
+use crate::runtime::AccountIdFor;
 
 type BalanceOf<R> = <R as pallet_balances::Config>::Balance;
 
-impl<Config: SandboxConfig> Sandbox<Config>
+/// Balance API for the sandbox.
+pub trait BalanceAPI<T: Sandbox>
 where
-    Config::Runtime: pallet_balances::Config,
+    T: Sandbox,
+    T::Runtime: pallet_balances::Config,
 {
     /// Mint tokens to an account.
     ///
@@ -16,25 +18,54 @@ where
     ///
     /// * `address` - The address of the account to add tokens to.
     /// * `amount` - The number of tokens to add.
-    pub fn mint_into(
+    fn mint_into(
         &mut self,
-        address: AccountIdFor<Config::Runtime>,
-        amount: BalanceOf<Config::Runtime>,
-    ) -> Result<BalanceOf<Config::Runtime>, DispatchError> {
-        self.execute_with(|| {
-            pallet_balances::Pallet::<Config::Runtime>::mint_into(&address, amount)
-        })
-    }
+        address: &AccountIdFor<T::Runtime>,
+        amount: BalanceOf<T::Runtime>,
+    ) -> Result<BalanceOf<T::Runtime>, DispatchError>;
 
     /// Return the free balance of an account.
     ///
     /// # Arguments
     ///
     /// * `address` - The address of the account to query.
-    pub fn free_balance(
+    fn free_balance(&mut self, address: &AccountIdFor<T::Runtime>) -> BalanceOf<T::Runtime>;
+}
+
+impl<T> BalanceAPI<T> for T
+where
+    T: Sandbox,
+    T::Runtime: pallet_balances::Config,
+{
+    fn mint_into(
         &mut self,
-        address: &AccountIdFor<Config::Runtime>,
-    ) -> BalanceOf<Config::Runtime> {
-        self.execute_with(|| pallet_balances::Pallet::<Config::Runtime>::free_balance(address))
+        address: &AccountIdFor<T::Runtime>,
+        amount: BalanceOf<T::Runtime>,
+    ) -> Result<BalanceOf<T::Runtime>, DispatchError> {
+        self.execute_with(|| pallet_balances::Pallet::<T::Runtime>::mint_into(address, amount))
+    }
+
+    fn free_balance(&mut self, address: &AccountIdFor<T::Runtime>) -> BalanceOf<T::Runtime> {
+        self.execute_with(|| pallet_balances::Pallet::<T::Runtime>::free_balance(address))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::MinimalSandbox;
+    #[test]
+    fn mint_works() {
+        let mut sandbox = MinimalSandbox::default();
+        let balance = sandbox.free_balance(&MinimalSandbox::default_actor());
+
+        sandbox
+            .mint_into(&MinimalSandbox::default_actor(), 100)
+            .unwrap();
+
+        assert_eq!(
+            sandbox.free_balance(&MinimalSandbox::default_actor()),
+            balance + 100
+        );
     }
 }

--- a/drink/src/sandbox/system_api.rs
+++ b/drink/src/sandbox/system_api.rs
@@ -1,26 +1,37 @@
 //! System API for the sandbox.
 
-use frame_support::sp_runtime::{traits::Dispatchable, DispatchResultWithInfo};
+use frame_support::sp_runtime::{
+    traits::{Dispatchable, Saturating},
+    DispatchResultWithInfo,
+};
 use frame_system::pallet_prelude::BlockNumberFor;
 
 use super::Sandbox;
-use crate::{EventRecordOf, RuntimeCall, SandboxConfig};
+use crate::{EventRecordOf, RuntimeCall};
 
-impl<Config: SandboxConfig> Sandbox<Config> {
+/// System API for the sandbox.
+pub trait SystemAPI {
+    /// The runtime system config.
+    type T: frame_system::Config;
+
+    /// Build a new empty block and return the new height.
+    fn build_block(&mut self) -> BlockNumberFor<Self::T>;
+
+    /// Build `n` empty blocks and return the new height.
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - The number of blocks to build.
+    fn build_blocks(&mut self, n: u32) -> BlockNumberFor<Self::T>;
+
     /// Return the current height of the chain.
-    pub fn block_number(&mut self) -> BlockNumberFor<Config::Runtime> {
-        self.execute_with(frame_system::Pallet::<Config::Runtime>::block_number)
-    }
+    fn block_number(&mut self) -> BlockNumberFor<Self::T>;
 
     /// Return the events of the current block so far.
-    pub fn events(&mut self) -> Vec<EventRecordOf<Config::Runtime>> {
-        self.execute_with(frame_system::Pallet::<Config::Runtime>::events)
-    }
+    fn events(&mut self) -> Vec<EventRecordOf<Self::T>>;
 
     /// Reset the events of the current block.
-    pub fn reset_events(&mut self) {
-        self.execute_with(frame_system::Pallet::<Config::Runtime>::reset_events)
-    }
+    fn reset_events(&mut self);
 
     /// Execute a runtime call (dispatchable).
     ///
@@ -28,13 +39,55 @@ impl<Config: SandboxConfig> Sandbox<Config> {
     ///
     /// * `call` - The runtime call to execute.
     /// * `origin` - The origin of the call.
-    pub fn runtime_call<
-        Origin: Into<<RuntimeCall<Config::Runtime> as Dispatchable>::RuntimeOrigin>,
-    >(
+    fn runtime_call<Origin: Into<<RuntimeCall<Self::T> as Dispatchable>::RuntimeOrigin>>(
         &mut self,
-        call: RuntimeCall<Config::Runtime>,
+        call: RuntimeCall<Self::T>,
         origin: Origin,
-    ) -> DispatchResultWithInfo<<RuntimeCall<Config::Runtime> as Dispatchable>::PostInfo> {
+    ) -> DispatchResultWithInfo<<RuntimeCall<Self::T> as Dispatchable>::PostInfo>;
+}
+
+impl<T> SystemAPI for T
+where
+    T: Sandbox,
+    T::Runtime: frame_system::Config,
+{
+    type T = T::Runtime;
+
+    fn build_block(&mut self) -> BlockNumberFor<Self::T> {
+        self.execute_with(|| {
+            let mut current_block = frame_system::Pallet::<Self::T>::block_number();
+            let block_hash = T::finalize_block(current_block);
+            current_block.saturating_inc();
+            T::initialize_block(current_block, block_hash);
+            current_block
+        })
+    }
+
+    fn build_blocks(&mut self, n: u32) -> BlockNumberFor<Self::T> {
+        let mut last_block = None;
+        for _ in 0..n {
+            last_block = Some(self.build_block());
+        }
+        last_block.unwrap_or_else(|| self.block_number())
+    }
+
+    fn block_number(&mut self) -> BlockNumberFor<Self::T> {
+        self.execute_with(frame_system::Pallet::<Self::T>::block_number)
+    }
+
+    fn events(&mut self) -> Vec<EventRecordOf<Self::T>> {
+        self.execute_with(frame_system::Pallet::<Self::T>::events)
+    }
+
+    fn reset_events(&mut self) {
+        self.execute_with(frame_system::Pallet::<Self::T>::reset_events)
+    }
+
+    fn runtime_call<Origin: Into<<RuntimeCall<Self::T> as Dispatchable>::RuntimeOrigin>>(
+        &mut self,
+        call: RuntimeCall<Self::T>,
+        origin: Origin,
+    ) -> DispatchResultWithInfo<<RuntimeCall<Self::T> as Dispatchable>::PostInfo> {
         self.execute_with(|| call.dispatch(origin.into()))
     }
 }
@@ -44,40 +97,43 @@ mod tests {
     use frame_support::sp_runtime::{traits::Dispatchable, DispatchResultWithInfo};
 
     use crate::{
-        runtime::{minimal::RuntimeEvent, MinimalRuntime},
-        AccountId32, RuntimeCall, Sandbox, SandboxConfig,
+        minimal::{MinimalSandbox, MinimalSandboxRuntime},
+        runtime::minimal::RuntimeEvent,
+        sandbox::prelude::*,
+        AccountId32, RuntimeCall, Sandbox,
     };
 
     fn make_transfer(
-        sandbox: &mut Sandbox<MinimalRuntime>,
+        sandbox: &mut MinimalSandbox,
         dest: AccountId32,
         value: u128,
-    ) -> DispatchResultWithInfo<<RuntimeCall<MinimalRuntime> as Dispatchable>::PostInfo> {
+    ) -> DispatchResultWithInfo<<RuntimeCall<MinimalSandboxRuntime> as Dispatchable>::PostInfo>
+    {
         assert_ne!(
-            MinimalRuntime::default_actor(),
+            MinimalSandbox::default_actor(),
             dest,
             "make_transfer should send to account different than default_actor"
         );
         sandbox.runtime_call(
-            RuntimeCall::<MinimalRuntime>::Balances(
-                pallet_balances::Call::<MinimalRuntime>::transfer_allow_death {
-                    dest: dest.into(),
-                    value,
-                },
-            ),
-            Some(MinimalRuntime::default_actor()),
+            RuntimeCall::<MinimalSandboxRuntime>::Balances(pallet_balances::Call::<
+                MinimalSandboxRuntime,
+            >::transfer_allow_death {
+                dest: dest.into(),
+                value,
+            }),
+            Some(MinimalSandbox::default_actor()),
         )
     }
 
     #[test]
     fn dry_run_works() {
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
-        let actor = MinimalRuntime::default_actor();
+        let mut sandbox = MinimalSandbox::default();
+        let actor = MinimalSandbox::default_actor();
         let initial_balance = sandbox.free_balance(&actor);
 
-        sandbox.dry_run(|runtime| {
-            runtime.mint_into(actor.clone(), 100).unwrap();
-            assert_eq!(runtime.free_balance(&actor), initial_balance + 100);
+        sandbox.dry_run(|sandbox| {
+            sandbox.mint_into(&actor, 100).unwrap();
+            assert_eq!(sandbox.free_balance(&actor), initial_balance + 100);
         });
 
         assert_eq!(sandbox.free_balance(&actor), initial_balance);
@@ -85,7 +141,7 @@ mod tests {
 
     #[test]
     fn runtime_call_works() {
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
+        let mut sandbox = MinimalSandbox::default();
 
         const RECIPIENT: AccountId32 = AccountId32::new([2u8; 32]);
         let initial_balance = sandbox.free_balance(&RECIPIENT);
@@ -99,7 +155,7 @@ mod tests {
 
     #[test]
     fn current_events() {
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
+        let mut sandbox = MinimalSandbox::default();
         const RECIPIENT: AccountId32 = AccountId32::new([2u8; 32]);
 
         let events_before = sandbox.events();
@@ -117,7 +173,7 @@ mod tests {
 
     #[test]
     fn resetting_events() {
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
+        let mut sandbox = MinimalSandbox::default();
         const RECIPIENT: AccountId32 = AccountId32::new([3u8; 32]);
 
         make_transfer(&mut sandbox, RECIPIENT.clone(), 1).expect("Failed to make transfer");

--- a/drink/src/sandbox/timestamp_api.rs
+++ b/drink/src/sandbox/timestamp_api.rs
@@ -1,42 +1,55 @@
 //! timestamp API for the sandbox.
 
-use crate::{Sandbox, SandboxConfig};
+use crate::Sandbox;
 
 /// Generic Time type.
 type MomentOf<R> = <R as pallet_timestamp::Config>::Moment;
 
-impl<Config: SandboxConfig> Sandbox<Config>
-where
-    Config::Runtime: pallet_timestamp::Config,
-{
+/// Timestamp API used to interact with the timestamp pallet.
+pub trait TimestampAPI {
+    /// The runtime timestamp config.
+    type T: pallet_timestamp::Config;
+
     /// Return the timestamp of the current block.
-    pub fn get_timestamp(&mut self) -> MomentOf<Config::Runtime> {
-        self.execute_with(pallet_timestamp::Pallet::<Config::Runtime>::get)
-    }
+    fn get_timestamp(&mut self) -> MomentOf<Self::T>;
 
     /// Set the timestamp of the current block.
     ///
     /// # Arguments
     ///
     /// * `timestamp` - The new timestamp to be set.
-    pub fn set_timestamp(&mut self, timestamp: MomentOf<Config::Runtime>) {
-        self.execute_with(|| pallet_timestamp::Pallet::<Config::Runtime>::set_timestamp(timestamp))
+    fn set_timestamp(&mut self, timestamp: MomentOf<Self::T>);
+}
+
+impl<T> TimestampAPI for T
+where
+    T: Sandbox,
+    T::Runtime: pallet_timestamp::Config,
+{
+    type T = T::Runtime;
+
+    fn get_timestamp(&mut self) -> MomentOf<Self::T> {
+        self.execute_with(pallet_timestamp::Pallet::<T::Runtime>::get)
+    }
+
+    fn set_timestamp(&mut self, timestamp: MomentOf<Self::T>) {
+        self.execute_with(|| pallet_timestamp::Pallet::<T::Runtime>::set_timestamp(timestamp))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{runtime::MinimalRuntime, Sandbox};
+    use crate::{runtime::MinimalSandbox, sandbox::prelude::*};
 
     #[test]
     fn getting_and_setting_timestamp_works() {
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
+        let mut sandbox = MinimalSandbox::default();
         for timestamp in 0..10 {
             assert_ne!(sandbox.get_timestamp(), timestamp);
             sandbox.set_timestamp(timestamp);
             assert_eq!(sandbox.get_timestamp(), timestamp);
 
-            sandbox.build_block().expect("Failed to build block");
+            sandbox.build_block();
         }
     }
 }

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -15,13 +15,12 @@ use pallet_contracts::Determinism;
 use parity_scale_codec::Decode;
 pub use record::{EventBatch, Record};
 
-use self::mocking_api::MockingApi;
 use crate::{
     runtime::{
         pallet_contracts_debugging::{InterceptingExt, TracingExt},
-        AccountIdFor, HashFor, MinimalRuntime,
+        AccountIdFor, HashFor,
     },
-    sandbox::SandboxConfig,
+    sandbox::prelude::*,
     session::mock::MockRegistry,
     ContractExecResultFor, ContractInstantiateResultFor, Sandbox, DEFAULT_GAS_LIMIT,
 };
@@ -36,7 +35,10 @@ mod transcoding;
 
 pub use bundle::ContractBundle;
 
-use crate::{errors::MessageResult, session::transcoding::TranscoderRegistry};
+use self::mocking_api::MockingApi;
+use crate::{
+    errors::MessageResult, minimal::MinimalSandboxRuntime, session::transcoding::TranscoderRegistry,
+};
 
 type BalanceOf<R> =
     <<R as pallet_contracts::Config>::Currency as Inspect<AccountIdFor<R>>>::Balance;
@@ -51,7 +53,7 @@ pub const NO_SALT: Vec<u8> = vec![];
 /// Convenient value for no endowment.
 ///
 /// Compatible with any runtime with `u128` as the balance type.
-pub const NO_ENDOWMENT: Option<BalanceOf<MinimalRuntime>> = None;
+pub const NO_ENDOWMENT: Option<BalanceOf<MinimalSandboxRuntime>> = None;
 
 /// Wrapper around `Sandbox` that provides a convenient API for interacting with multiple contracts.
 ///
@@ -66,7 +68,7 @@ pub const NO_ENDOWMENT: Option<BalanceOf<MinimalRuntime>> = None;
 /// #   session::Session,
 /// #   AccountId32,
 /// #   session::{NO_ARGS, NO_SALT, NO_ENDOWMENT},
-/// #   runtime::MinimalRuntime
+/// #   runtime::MinimalSandbox
 /// # };
 /// #
 /// # fn get_transcoder() -> Rc<ContractMessageTranscoder> {
@@ -77,7 +79,7 @@ pub const NO_ENDOWMENT: Option<BalanceOf<MinimalRuntime>> = None;
 ///
 /// # fn main() -> Result<(), drink::session::error::SessionError> {
 ///
-/// Session::<MinimalRuntime>::new()?
+/// Session::<MinimalSandbox>::default()
 ///     .deploy_and(contract_bytes(), "new", NO_ARGS, NO_SALT, NO_ENDOWMENT, &get_transcoder())?
 ///     .call_and("foo", NO_ARGS, NO_ENDOWMENT)?
 ///     .with_actor(bob())
@@ -92,7 +94,7 @@ pub const NO_ENDOWMENT: Option<BalanceOf<MinimalRuntime>> = None;
 /// # use drink::{
 /// #   session::Session,
 /// #   AccountId32,
-/// #   runtime::MinimalRuntime,
+/// #   runtime::MinimalSandbox,
 /// #   session::{NO_ARGS, NO_ENDOWMENT, NO_SALT}
 /// # };
 /// # fn get_transcoder() -> Rc<ContractMessageTranscoder> {
@@ -103,7 +105,7 @@ pub const NO_ENDOWMENT: Option<BalanceOf<MinimalRuntime>> = None;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///
-/// let mut session = Session::<MinimalRuntime>::new()?;
+/// let mut session = Session::<MinimalSandbox>::default();
 /// let _address = session.deploy(contract_bytes(), "new", NO_ARGS, NO_SALT, NO_ENDOWMENT, &get_transcoder())?;
 /// let _result: u32 = session.call("foo", NO_ARGS, NO_ENDOWMENT)??;
 /// session.set_actor(bob());
@@ -117,73 +119,75 @@ pub const NO_ENDOWMENT: Option<BalanceOf<MinimalRuntime>> = None;
 /// #   local_contract_file,
 /// #   session::Session,
 /// #   session::{ContractBundle, NO_ARGS, NO_SALT, NO_ENDOWMENT},
-/// #   runtime::MinimalRuntime,
+/// #   runtime::MinimalSandbox,
 /// # };
 ///
 /// # fn main() -> Result<(), drink::session::error::SessionError> {
 /// // Simplest way, loading a bundle from the project's directory:
-/// Session::<MinimalRuntime>::new()?
+/// Session::<MinimalSandbox>::default()
 ///     .deploy_bundle_and(local_contract_file!(), "new", NO_ARGS, NO_SALT, NO_ENDOWMENT)?; /* ... */
 ///
 /// // Or choosing the file explicitly:
 /// let contract = ContractBundle::load("path/to/your.contract")?;
-/// Session::<MinimalRuntime>::new()?
+/// Session::<MinimalSandbox>::default()
 ///     .deploy_bundle_and(contract, "new", NO_ARGS, NO_SALT, NO_ENDOWMENT)?; /* ... */
 ///  # Ok(()) }
 /// ```
-pub struct Session<Config: SandboxConfig>
+pub struct Session<T: Sandbox>
 where
-    Config::Runtime: pallet_contracts::Config,
+    T::Runtime: pallet_contracts::Config,
 {
-    sandbox: Sandbox<Config>,
+    sandbox: T,
 
-    actor: AccountIdFor<Config::Runtime>,
+    actor: AccountIdFor<T::Runtime>,
     gas_limit: Weight,
     determinism: Determinism,
 
-    transcoders: TranscoderRegistry<AccountIdFor<Config::Runtime>>,
-    record: Record<Config::Runtime>,
-    mocks: Arc<Mutex<MockRegistry<AccountIdFor<Config::Runtime>>>>,
+    transcoders: TranscoderRegistry<AccountIdFor<T::Runtime>>,
+    record: Record<T::Runtime>,
+    mocks: Arc<Mutex<MockRegistry<AccountIdFor<T::Runtime>>>>,
 }
 
-impl<Config: SandboxConfig> Session<Config>
+impl<T: Sandbox> Default for Session<T>
 where
-    Config::Runtime: pallet_contracts::Config,
+    T::Runtime: pallet_contracts::Config,
+    T: Default,
 {
-    /// Creates a new `Session`.
-    pub fn new() -> Result<Self, SessionError> {
+    fn default() -> Self {
         let mocks = Arc::new(Mutex::new(MockRegistry::new()));
-        let mut sandbox = Sandbox::new().map_err(SessionError::Drink)?;
+        let mut sandbox = T::default();
         sandbox.register_extension(InterceptingExt(Box::new(MockingExtension {
             mock_registry: Arc::clone(&mocks),
         })));
 
-        Ok(Self {
+        Self {
             sandbox,
             mocks,
-            actor: Config::default_actor(),
+            actor: T::default_actor(),
             gas_limit: DEFAULT_GAS_LIMIT,
             determinism: Determinism::Enforced,
             transcoders: TranscoderRegistry::new(),
             record: Default::default(),
-        })
+        }
     }
+}
 
+impl<T: Sandbox> Session<T>
+where
+    T::Runtime: pallet_contracts::Config,
+{
     /// Sets a new actor and returns updated `self`.
-    pub fn with_actor(self, actor: AccountIdFor<Config::Runtime>) -> Self {
+    pub fn with_actor(self, actor: AccountIdFor<T::Runtime>) -> Self {
         Self { actor, ..self }
     }
 
     /// Returns currently set actor.
-    pub fn get_actor(&self) -> AccountIdFor<Config::Runtime> {
+    pub fn get_actor(&self) -> AccountIdFor<T::Runtime> {
         self.actor.clone()
     }
 
     /// Sets a new actor and returns the old one.
-    pub fn set_actor(
-        &mut self,
-        actor: AccountIdFor<Config::Runtime>,
-    ) -> AccountIdFor<Config::Runtime> {
+    pub fn set_actor(&mut self, actor: AccountIdFor<T::Runtime>) -> AccountIdFor<T::Runtime> {
         mem::replace(&mut self.actor, actor)
     }
 
@@ -218,7 +222,7 @@ where
     /// Register a transcoder for a particular contract and returns updated `self`.
     pub fn with_transcoder(
         mut self,
-        contract_address: AccountIdFor<Config::Runtime>,
+        contract_address: AccountIdFor<T::Runtime>,
         transcoder: &Rc<ContractMessageTranscoder>,
     ) -> Self {
         self.set_transcoder(contract_address, transcoder);
@@ -228,24 +232,24 @@ where
     /// Registers a transcoder for a particular contract.
     pub fn set_transcoder(
         &mut self,
-        contract_address: AccountIdFor<Config::Runtime>,
+        contract_address: AccountIdFor<T::Runtime>,
         transcoder: &Rc<ContractMessageTranscoder>,
     ) {
         self.transcoders.register(contract_address, transcoder);
     }
 
     /// The underlying `Sandbox` instance.
-    pub fn sandbox(&mut self) -> &mut Sandbox<Config> {
+    pub fn sandbox(&mut self) -> &mut T {
         &mut self.sandbox
     }
 
     /// Returns a reference to the record of the session.
-    pub fn record(&self) -> &Record<Config::Runtime> {
+    pub fn record(&self) -> &Record<T::Runtime> {
         &self.record
     }
 
     /// Returns a reference for mocking API.
-    pub fn mocking_api(&mut self) -> &mut impl MockingApi<Config::Runtime> {
+    pub fn mocking_api(&mut self) -> &mut impl MockingApi<T::Runtime> {
         self
     }
 
@@ -257,7 +261,7 @@ where
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
-        endowment: Option<BalanceOf<Config::Runtime>>,
+        endowment: Option<BalanceOf<T::Runtime>>,
         transcoder: &Rc<ContractMessageTranscoder>,
     ) -> Result<Self, SessionError> {
         self.deploy(
@@ -270,8 +274,7 @@ where
         )
         .map(|_| self)
     }
-
-    fn record_events<T>(&mut self, recording: impl FnOnce(&mut Self) -> T) -> T {
+    fn record_events<V>(&mut self, recording: impl FnOnce(&mut Self) -> V) -> V {
         let start = self.sandbox.events().len();
         let result = recording(self);
         let events = self.sandbox.events()[start..].to_vec();
@@ -287,9 +290,9 @@ where
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
-        endowment: Option<BalanceOf<Config::Runtime>>,
+        endowment: Option<BalanceOf<T::Runtime>>,
         transcoder: &Rc<ContractMessageTranscoder>,
-    ) -> Result<AccountIdFor<Config::Runtime>, SessionError> {
+    ) -> Result<AccountIdFor<T::Runtime>, SessionError> {
         let data = transcoder
             .encode(constructor, args)
             .map_err(|err| SessionError::Encoding(err.to_string()))?;
@@ -333,8 +336,8 @@ where
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
-        endowment: Option<BalanceOf<Config::Runtime>>,
-    ) -> Result<AccountIdFor<Config::Runtime>, SessionError> {
+        endowment: Option<BalanceOf<T::Runtime>>,
+    ) -> Result<AccountIdFor<T::Runtime>, SessionError> {
         self.deploy(
             contract_file.wasm,
             constructor,
@@ -352,8 +355,8 @@ where
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
-        endowment: Option<BalanceOf<Config::Runtime>>,
-    ) -> Result<ContractInstantiateResultFor<Config::Runtime>, SessionError> {
+        endowment: Option<BalanceOf<T::Runtime>>,
+    ) -> Result<ContractInstantiateResultFor<T::Runtime>, SessionError> {
         let data = contract_file
             .transcoder
             .encode(constructor, args)
@@ -381,7 +384,7 @@ where
         constructor: &str,
         args: &[S],
         salt: Vec<u8>,
-        endowment: Option<BalanceOf<Config::Runtime>>,
+        endowment: Option<BalanceOf<T::Runtime>>,
     ) -> Result<Self, SessionError> {
         self.deploy_bundle(contract_file, constructor, args, salt, endowment)
             .map(|_| self)
@@ -393,10 +396,7 @@ where
     }
 
     /// Uploads a raw contract code. In case of success returns the code hash.
-    pub fn upload(
-        &mut self,
-        contract_bytes: Vec<u8>,
-    ) -> Result<HashFor<Config::Runtime>, SessionError> {
+    pub fn upload(&mut self, contract_bytes: Vec<u8>) -> Result<HashFor<T::Runtime>, SessionError> {
         let result = self.sandbox.upload_contract(
             contract_bytes,
             self.actor.clone(),
@@ -422,7 +422,7 @@ where
     pub fn upload_bundle(
         &mut self,
         contract_file: ContractBundle,
-    ) -> Result<HashFor<Config::Runtime>, SessionError> {
+    ) -> Result<HashFor<T::Runtime>, SessionError> {
         self.upload(contract_file.wasm)
     }
 
@@ -431,7 +431,7 @@ where
         mut self,
         message: &str,
         args: &[S],
-        endowment: Option<BalanceOf<Config::Runtime>>,
+        endowment: Option<BalanceOf<T::Runtime>>,
     ) -> Result<Self, SessionError> {
         // We ignore result, so we can pass `()` as the message result type, which will never fail
         // at decoding.
@@ -442,10 +442,10 @@ where
     /// Calls the last deployed contract. In case of a successful call, returns `self`.
     pub fn call_with_address_and<S: AsRef<str> + Debug>(
         mut self,
-        address: AccountIdFor<Config::Runtime>,
+        address: AccountIdFor<T::Runtime>,
         message: &str,
         args: &[S],
-        endowment: Option<BalanceOf<Config::Runtime>>,
+        endowment: Option<BalanceOf<T::Runtime>>,
     ) -> Result<Self, SessionError> {
         // We ignore result, so we can pass `()` as the message result type, which will never fail
         // at decoding.
@@ -454,35 +454,35 @@ where
     }
 
     /// Calls the last deployed contract. In case of a successful call, returns the encoded result.
-    pub fn call<S: AsRef<str> + Debug, T: Decode>(
+    pub fn call<S: AsRef<str> + Debug, V: Decode>(
         &mut self,
         message: &str,
         args: &[S],
-        endowment: Option<BalanceOf<Config::Runtime>>,
-    ) -> Result<MessageResult<T>, SessionError> {
-        self.call_internal::<_, T>(None, message, args, endowment)
+        endowment: Option<BalanceOf<T::Runtime>>,
+    ) -> Result<MessageResult<V>, SessionError> {
+        self.call_internal::<_, V>(None, message, args, endowment)
     }
 
     /// Calls a contract with a given address. In case of a successful call, returns the encoded
     /// result.
-    pub fn call_with_address<S: AsRef<str> + Debug, T: Decode>(
+    pub fn call_with_address<S: AsRef<str> + Debug, V: Decode>(
         &mut self,
-        address: AccountIdFor<Config::Runtime>,
+        address: AccountIdFor<T::Runtime>,
         message: &str,
         args: &[S],
-        endowment: Option<BalanceOf<Config::Runtime>>,
-    ) -> Result<MessageResult<T>, SessionError> {
+        endowment: Option<BalanceOf<T::Runtime>>,
+    ) -> Result<MessageResult<V>, SessionError> {
         self.call_internal(Some(address), message, args, endowment)
     }
 
     /// Performs a dry run of a contract call.
     pub fn dry_run_call<S: AsRef<str> + Debug>(
         &mut self,
-        address: AccountIdFor<Config::Runtime>,
+        address: AccountIdFor<T::Runtime>,
         message: &str,
         args: &[S],
-        endowment: Option<BalanceOf<Config::Runtime>>,
-    ) -> Result<ContractExecResultFor<Config::Runtime>, SessionError> {
+        endowment: Option<BalanceOf<T::Runtime>>,
+    ) -> Result<ContractExecResultFor<T::Runtime>, SessionError> {
         let data = self
             .transcoders
             .get(&address)
@@ -504,13 +504,13 @@ where
         }))
     }
 
-    fn call_internal<S: AsRef<str> + Debug, T: Decode>(
+    fn call_internal<S: AsRef<str> + Debug, V: Decode>(
         &mut self,
-        address: Option<AccountIdFor<Config::Runtime>>,
+        address: Option<AccountIdFor<T::Runtime>>,
         message: &str,
         args: &[S],
-        endowment: Option<BalanceOf<Config::Runtime>>,
-    ) -> Result<MessageResult<T>, SessionError> {
+        endowment: Option<BalanceOf<T::Runtime>>,
+    ) -> Result<MessageResult<V>, SessionError> {
         let address = match address {
             Some(address) => address,
             None => self
@@ -545,7 +545,7 @@ where
             Ok(exec_result) if exec_result.did_revert() => Err(SessionError::CallReverted),
             Ok(exec_result) => {
                 self.record.push_call_return(exec_result.data.clone());
-                self.record.last_call_return_decoded::<T>()
+                self.record.last_call_return_decoded::<V>()
             }
             Err(err) => Err(SessionError::CallFailed(*err)),
         };

--- a/drink/src/session/mocking_api.rs
+++ b/drink/src/session/mocking_api.rs
@@ -1,6 +1,8 @@
 //! Mocking API for the sandbox.
 use super::Session;
-use crate::{runtime::AccountIdFor, session::mock::ContractMock, SandboxConfig, DEFAULT_GAS_LIMIT};
+use crate::{
+    runtime::AccountIdFor, sandbox::prelude::*, session::mock::ContractMock, DEFAULT_GAS_LIMIT,
+};
 
 /// Interface for basic mocking operations.
 pub trait MockingApi<R: pallet_contracts::Config> {
@@ -12,11 +14,11 @@ pub trait MockingApi<R: pallet_contracts::Config> {
     fn mock_existing_contract(&mut self, _mock: ContractMock, _address: AccountIdFor<R>);
 }
 
-impl<Config: SandboxConfig> MockingApi<Config::Runtime> for Session<Config>
+impl<T: Sandbox> MockingApi<T::Runtime> for Session<T>
 where
-    Config::Runtime: pallet_contracts::Config,
+    T::Runtime: pallet_contracts::Config,
 {
-    fn deploy(&mut self, mock: ContractMock) -> AccountIdFor<Config::Runtime> {
+    fn deploy(&mut self, mock: ContractMock) -> AccountIdFor<T::Runtime> {
         // We have to deploy some contract. We use a dummy contract for that. Thanks to that, we
         // ensure that the pallet will treat our mock just as a regular contract, until we actually
         // call it.
@@ -34,7 +36,7 @@ where
                 0u32.into(),
                 vec![],
                 salt,
-                Config::default_actor(),
+                T::default_actor(),
                 DEFAULT_GAS_LIMIT,
                 None,
             )
@@ -50,11 +52,7 @@ where
         mock_address
     }
 
-    fn mock_existing_contract(
-        &mut self,
-        _mock: ContractMock,
-        _address: AccountIdFor<Config::Runtime>,
-    ) {
+    fn mock_existing_contract(&mut self, _mock: ContractMock, _address: AccountIdFor<T::Runtime>) {
         todo!("soon")
     }
 }

--- a/drink/src/session/record.rs
+++ b/drink/src/session/record.rs
@@ -5,7 +5,8 @@ use parity_scale_codec::{Decode, Encode};
 
 use crate::{
     errors::MessageResult,
-    runtime::{minimal::RuntimeEvent, AccountIdFor, MinimalRuntime},
+    minimal::MinimalSandboxRuntime,
+    runtime::{minimal::RuntimeEvent, AccountIdFor},
     session::{error::SessionError, BalanceOf},
     EventRecordOf,
 };
@@ -143,20 +144,22 @@ impl<R: frame_system::Config> EventBatch<R> {
     }
 }
 
-impl EventBatch<MinimalRuntime> {
+impl EventBatch<MinimalSandboxRuntime> {
     /// Returns all the contract events that were emitted during the contract interaction.
     ///
     /// **WARNING**: This method will return all the events that were emitted by ANY contract. If your
     /// call triggered multiple contracts, you will have to filter the events yourself.
     ///
     /// We have to match against static enum variant, and thus (at least for now) we support only
-    /// `MinimalRuntime`.
+    /// `MinimalSandbox`.
     pub fn contract_events(&self) -> Vec<&[u8]> {
         self.events
             .iter()
             .filter_map(|event| match &event.event {
                 RuntimeEvent::Contracts(
-                    pallet_contracts::Event::<MinimalRuntime>::ContractEmitted { data, .. },
+                    pallet_contracts::Event::<MinimalSandboxRuntime>::ContractEmitted {
+                        data, ..
+                    },
                 ) => Some(data.as_slice()),
                 _ => None,
             })

--- a/examples/chain-extension/Cargo.lock
+++ b/examples/chain-extension/Cargo.lock
@@ -1344,7 +1344,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1358,6 +1358,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1369,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/chain-extension/Cargo.toml
+++ b/examples/chain-extension/Cargo.toml
@@ -18,7 +18,7 @@ scale-info = { version = "2.6", default-features = false, features = ["derive"],
 [dev-dependencies]
 drink = { path = "../../drink" }
 
-# If you are creating a custom runtime with `drink::create_minimal_runtime!` macro, unfortunately you need to
+# If you are creating a custom runtime with `drink::create_minimal_sandbox!` macro, unfortunately you need to
 # include these dependencies manually. Versions should match the ones in `Cargo.toml` of the `drink` crate.
 frame-support = "30.0.0"
 frame-system = "30.0.0"

--- a/examples/chain-extension/README.md
+++ b/examples/chain-extension/README.md
@@ -3,18 +3,20 @@
 This example shows how you can use `drink` to test a chain extension.
 
 From the perspective of a contract implementation or writing tests there is nothing special (i.e., more than usual) that you have to do to interact with a chain extension.
-The thing that `drink` makes easier for you is combining an arbitrary chain extension with `drink`'s `MinimalRuntime`.
+The thing that `drink` makes easier for you is combining an arbitrary chain extension with `drink`'s `MinimalSandbox`.
 By simply calling:
+
 ```rust
-create_minimal_runtime!(
-    RuntimeWithCustomChainExtension,
+create_minimal_sandbox!(
+    SandboxWithCustomChainExtension,
     path::to::MyCustomChainExtension
 );
 ```
 
-you are provided with a runtime that contains your custom chain extension and can be used to test your contract like:
+you are provided with a `Sandbox` with a runtime that contains your custom chain extension and can be used to test your contract like:
+
 ```rust
-Session::<RuntimeWithCustomChainExtension>::new()?
+Session::<SandboxWithCustomChainExtension>::default()
     .deploy_bundle_and(...)?
     .call(...)?
 ```

--- a/examples/chain-extension/src/lib.rs
+++ b/examples/chain-extension/src/lib.rs
@@ -36,7 +36,7 @@ mod contract_calling_chain_extension {
 #[cfg(test)]
 mod tests {
     use drink::{
-        create_minimal_runtime,
+        create_minimal_sandbox,
         session::{Session, NO_ARGS, NO_ENDOWMENT, NO_SALT},
     };
 
@@ -46,13 +46,13 @@ mod tests {
     enum BundleProvider {}
 
     // We can inject arbitrary chain extension into the minimal runtime as follows:
-    create_minimal_runtime!(
+    create_minimal_sandbox!(
         SandboxWithCE,
         crate::chain_extension_runtime_side::StakingExtension
     );
 
     /// Test that we can call chain extension from ink! contract and get a correct result.
-    #[drink::test(config = SandboxWithCE)]
+    #[drink::test(sandbox = SandboxWithCE)]
     fn we_can_test_chain_extension(mut session: Session) -> Result<(), Box<dyn std::error::Error>> {
         let result: u32 = session
             .deploy_bundle_and(

--- a/examples/contract-events/Cargo.lock
+++ b/examples/contract-events/Cargo.lock
@@ -1338,7 +1338,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1352,6 +1352,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1363,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/contract-events/README.md
+++ b/examples/contract-events/README.md
@@ -4,8 +4,9 @@ This example shows how we can extract events that were emitted by a contract.
 
 When you are working with a `Session` object, you can consult its `Record` - a data structure that collects all the results and events that have been produced while interacting with contracts.
 For example:
+
 ```rust
-let mut session = Session::<MinimalRuntime>::new()?;
+let mut session = Session::<MinimalSandbox>::default();
 // .. some contract interaction
 
 // `record` is a `Record` object that contains all the results and events that have been produced while interacting with contracts.
@@ -13,6 +14,7 @@ let record = session.record();
 ```
 
 Given a `Record` object, we can extract the results of the contract interaction:
+
 ```rust
 // `deploy_returns` returns a vector of contract addresses that have been deployed during the session.
 let all_deployed_contracts = record.deploy_returns();
@@ -21,6 +23,7 @@ let last_call_value = record.last_call_return_decoded::<CustomType>();
 ```
 
 as well as the events that have been emitted by contracts:
+
 ```rust
 // `last_event_batch` returns the batch of runtime events that have been emitted during last contract interaction.
 let last_event_batch = record.last_event_batch();

--- a/examples/cross-contract-call-tracing/Cargo.lock
+++ b/examples/cross-contract-call-tracing/Cargo.lock
@@ -1338,7 +1338,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.11.2"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1352,6 +1352,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1363,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.11.2"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/dry-running/Cargo.lock
+++ b/examples/dry-running/Cargo.lock
@@ -1324,7 +1324,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.11.2"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1338,6 +1338,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1349,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.11.2"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/dry-running/lib.rs
+++ b/examples/dry-running/lib.rs
@@ -30,10 +30,11 @@ mod counter {
 mod tests {
     use drink::{
         frame_support::sp_runtime::ModuleError,
-        minimal::RuntimeCall,
         pallet_balances,
+        runtime::{minimal::RuntimeCall, MinimalSandbox},
+        sandbox::prelude::*,
         session::{Session, NO_ARGS, NO_ENDOWMENT, NO_SALT},
-        AccountId32, DispatchError, MinimalRuntime, Sandbox, SandboxConfig,
+        AccountId32, DispatchError,
     };
 
     #[drink::contract_bundle_provider]
@@ -87,7 +88,7 @@ mod tests {
 
     #[test]
     fn we_can_dry_run_normal_runtime_transaction() {
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
+        let mut sandbox = MinimalSandbox::default();
 
         // Bob will be the recipient of the transfer.
         let bob = AccountId32::new([2u8; 32]);
@@ -103,7 +104,7 @@ mod tests {
                         dest: bob.clone().into(),
                         value: 100,
                     }),
-                    Some(MinimalRuntime::default_actor()),
+                    Some(MinimalSandbox::default_actor()),
                 )
                 .expect("Failed to execute a call")
         });

--- a/examples/flipper/Cargo.lock
+++ b/examples/flipper/Cargo.lock
@@ -1324,7 +1324,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1338,6 +1338,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1349,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",
@@ -1572,8 +1573,6 @@ name = "flipper"
 version = "0.1.0"
 dependencies = [
  "drink",
- "frame-support",
- "frame-system",
  "ink",
  "parity-scale-codec",
  "scale-info",

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -15,11 +15,6 @@ scale-info = { version = "2.6", default-features = false, features = ["derive"],
 [dev-dependencies]
 drink = { path = "../../drink" }
 
-# testing custom runtime
-frame-support = "30.0.0"
-frame-system = "30.0.0"
-
-
 [lib]
 path = "lib.rs"
 

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -71,24 +71,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[drink::test]
-    fn test_flipping_with_custom_runtime(
-        mut session: Session,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let contract = BundleProvider::Flipper.bundle()?;
-        let init_value: bool = session
-            .deploy_bundle_and(contract, "new", &["true"], NO_SALT, NO_ENDOWMENT)?
-            .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
-            .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
-            .call_and("flip", NO_ARGS, NO_ENDOWMENT)?
-            .call_and("get", NO_ARGS, NO_ENDOWMENT)?
-            .record()
-            .last_call_return_decoded()?
-            .expect("Call was successful");
-
-        assert_eq!(init_value, false);
-
-        Ok(())
-    }
 }

--- a/examples/mocking/Cargo.lock
+++ b/examples/mocking/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1342,6 +1342,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1353,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/multiple-contracts/Cargo.lock
+++ b/examples/multiple-contracts/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1342,6 +1342,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1353,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/quick-start-with-drink/Cargo.lock
+++ b/examples/quick-start-with-drink/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1342,6 +1342,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1353,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/quick-start-with-drink/lib.rs
+++ b/examples/quick-start-with-drink/lib.rs
@@ -72,7 +72,7 @@ mod tests {
     ///
     /// `drink::test` will already provide us with a `Session` object. It is a wrapper around a runtime and it exposes
     /// a broad API for interacting with it. Session is generic over the runtime type, but usually and by default, we
-    /// use `MinimalRuntime`, which is a minimalistic runtime that allows using smart contracts.
+    /// use `MinimalSandbox`, which is a minimalistic runtime that allows using smart contracts.
     #[drink::test]
     fn deploy_and_call_a_contract(mut session: Session) -> Result<(), Box<dyn std::error::Error>> {
         // Now we get the contract bundle from the `BundleProvider` enum. Since the current crate

--- a/examples/runtime-interaction/Cargo.lock
+++ b/examples/runtime-interaction/Cargo.lock
@@ -1322,7 +1322,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1336,6 +1336,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "serde_json",
  "sp-externalities",
@@ -1347,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",

--- a/examples/runtime-interaction/README.md
+++ b/examples/runtime-interaction/README.md
@@ -12,13 +12,14 @@ cargo test --release
 
 ## `drink::Sandbox` vs `drink::Session`
 
-While in most examples and showcases for `drink` you will see `drink::Session`, here we are using `drink::Sandbox`.
-`Session` is very useful when you are working with contracts, but if you are focusing only on the runtime interaction, `Sandbox` is enough.
-You can always switch from `Session` to `Sandbox` with:
+While in most examples and showcases for `drink` you will see `drink::Session`, here we are using the associated `Sandbox` implementation directly.
+`Session` is very useful when you are working with contracts, but if you are focusing only on the runtime interaction, you can simply use the underlying `Sandbox`.
+You can get a reference to the `Sandbox` implementation from the `Session` object using the `sandbox` method:
+
 ```rust
-    let session = Session::<Runtime>::new();
+    let session = Session::<MinimalSandbox>::default();
     ...
-    let sandbox = session.sandbox(); // `sandbox` has type `&mut Sandbox<Runtime>`
+    let sandbox = session.sandbox(); // `sandbox` has type `&mut MinimalSandbox`
 ```
 
 `Sandbox` is just a runtime wrapper, which enables you to interact directly with the runtime.

--- a/examples/runtime-interaction/lib.rs
+++ b/examples/runtime-interaction/lib.rs
@@ -3,21 +3,22 @@ mod tests {
     use drink::{
         pallet_balances, pallet_contracts,
         pallet_contracts::Determinism,
-        runtime::{minimal::RuntimeCall, MinimalRuntime},
-        AccountId32, Sandbox, SandboxConfig,
+        runtime::{minimal::RuntimeCall, MinimalSandbox},
+        sandbox::prelude::*,
+        AccountId32,
     };
 
     #[test]
     fn we_can_make_a_token_transfer_call() {
         // We create a sandbox object, which represents a blockchain runtime.
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
+        let mut sandbox = MinimalSandbox::default();
 
         // Bob will be the recipient of the transfer.
         const BOB: AccountId32 = AccountId32::new([2u8; 32]);
 
         // Firstly, let us check that the recipient account (`BOB`) is not the default actor, that
         // will be used as the caller.
-        assert_ne!(MinimalRuntime::default_actor(), BOB);
+        assert_ne!(MinimalSandbox::default_actor(), BOB);
 
         // Recipient's balance before the transfer.
         let initial_balance = sandbox.free_balance(&BOB);
@@ -30,7 +31,7 @@ mod tests {
 
         // Submit the call to the runtime.
         sandbox
-            .runtime_call(call_object, Some(MinimalRuntime::default_actor()))
+            .runtime_call(call_object, Some(MinimalSandbox::default_actor()))
             .expect("Failed to execute a call");
 
         // In the end, the recipient's balance should be increased by 100.
@@ -39,14 +40,14 @@ mod tests {
 
     #[test]
     fn we_can_work_with_the_contracts_pallet_in_low_level() {
-        let mut sandbox = Sandbox::<MinimalRuntime>::new().expect("Failed to create sandbox");
+        let mut sandbox = MinimalSandbox::default();
 
         // A few runtime calls are also available directly from the sandbox. This includes a part of
         // the contracts API.
         let upload_result = sandbox
             .upload_contract(
                 wat::parse_str(CONTRACT).unwrap(),
-                MinimalRuntime::default_actor(),
+                MinimalSandbox::default_actor(),
                 None,
                 Determinism::Enforced,
             )
@@ -59,7 +60,7 @@ mod tests {
         });
 
         sandbox
-            .runtime_call(call_object, Some(MinimalRuntime::default_actor()))
+            .runtime_call(call_object, Some(MinimalSandbox::default_actor()))
             .expect("Failed to remove a contract");
     }
 


### PR DESCRIPTION
Follow up from #99 

I realized that the current design was not working as I wanted.
Specifically, when working with parachain and `xcm_simulator::TestExt`, I need to use the existing externalities, and 
the custom [`execute_with`](https://paritytech.github.io/polkadot-sdk/master/pallet_contracts_mock_network/trait.TestExt.html#method.execute_with) to dispatch messages properly.

- The Sandbox is now created inside the macro (renamed `create_minimal_sandbox`) along with the runtime. The default setup now uses the `MinimalSandbox`  created through the macro, instead of  (the now deleted) `Sandbox` struct.

- The trait `SandboxConfig` is renamed `Sandbox` and exposes these two new APIs
```rust
    fn execute_with<T>(&mut self, execute: impl FnOnce() -> T) -> T;
    fn dry_run<T>(&mut self, action: impl FnOnce(&mut Self) -> T) -> T;
```

- `fn initialize_storage` is removed since this can be done when the Sandbox is created, and can be customized there instead of being part of the trait.
- The api in `sandbox/*_api.rs` are updated to be traits with blanket implementations for `T: Sandbox` instead of impl blocks. 

These updates let us create custom sandbox environment that have full control over the storage and execution.
An example of this, is the `MockNetworkSandbox` defined in [ink!](https://github.com/paritytech/ink/blob/ff584cb9fa406c04d30d39c494a3ac371bb28011/crates/e2e/src/drink_client.rs#L472-L536)
that uses under the hood the xcm simulator to test connected smart contract that need to interact with a Network of chains.